### PR TITLE
Automatic installation of Calico on workload clusters

### DIFF
--- a/config/samples/calico-cni.yaml
+++ b/config/samples/calico-cni.yaml
@@ -4,12 +4,16 @@ metadata:
   name: calico-cni
 spec:
   clusterSelector:
-    matchLabels:
-      calicoCNI: enabled
+  # Target workload clusters with specific labels.
+  #  matchLabels:
+  #    calicoCNI: enabled
+  # Target all workload clusters.
+    matchLabels: {}
   releaseName: calico
-  repoURL: https://projectcalico.docs.tigera.io/charts
+  repoURL: https://docs.tigera.io/calico/charts
   chartName: tigera-operator
-  values: |
+  namespace: kube-system
+  valuesTemplate: |
     installation:
       cni:
         type: Calico

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,8 +47,19 @@ enable_providers:
 - helm 
 ```
 
+#### 3. Set up automatic installation for calico. (Optional)
 
-#### 3. Run Tilt
+Calico is automatically installed when workload clusters are started.  
+
+From `src/cluster-api-addon-provider-helm` run:
+
+```bash
+$ ./hack/setup-calico-autoinstallation.sh
+```
+
+See [Automatically install calico in workload clusters with Tilt](#automatically-install-calico-in-workload-clusters-with-tilt) for more details.
+
+#### 4. Run Tilt
 
 From `src/cluster-api` run:
 
@@ -57,3 +68,28 @@ $ make tilt-up
 ```
 
 From within Tilt, you should be able to see the CAAPH controller running alongside the Cluster API controllers with the CRDs installed.
+
+### Automatically install calico in workload clusters with Tilt
+
+Automatically install [calico](https://docs.tigera.io/calico) in workload clusters using the [yaml manifest](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/config/samples/calico-cni.yaml) provided by CAAPH.  
+The setup script(`setup-calico-autoinstallation.sh`) generates a tiltfile to incorporate the above yaml manifest as a Tilt resource.  
+
+**Setup script (`setup-calico-autoinstallation.sh`) Summary:**  
+- Generate the tiltfile to incorporate the above yaml manifest as a Tilt resource.
+  - Refer to [Tiltfile API Reference](https://docs.tilt.dev/api.html) for functions used in the tiltfile.
+- The tiltfile is output to the `src/cluster-api/tilt.d` directory.
+  - Run `make tilt-up` ,files under the `src/cluster-api/tilt.d` are automatically started. (excluding subdirectories)
+  
+
+The yaml manifest (`src/cluster-api-addon-provider-helm/config/samples/calico-cni.yaml`) is changed, it is redeployed by Tilt.  
+
+**For the target workload clusters**  
+The yaml manifest (`src/cluster-api-addon-provider-helm/config/samples/calico-cni.yaml`) is for all workload clusters.  <br>
+
+An example targeting workload clusters with a specific label.
+```yaml
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: calico 
+```

--- a/hack/setup-calico-autoinstallation.sh
+++ b/hack/setup-calico-autoinstallation.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+BASE_DIR=$(dirname "$0")
+CAPI_DIR=${BASE_DIR}/../../cluster-api
+TILTD_DIR=${CAPI_DIR}/tilt.d
+TILT_FILE=${TILTD_DIR}/calico_tiltfile
+
+# Check and create directories.
+[ -d "${CAPI_DIR}" ] && [ ! -d "${TILTD_DIR}" ] && mkdir -p "${TILTD_DIR}"
+
+# Generate the calico_tiltfile.
+cat <<EOF > "${TILT_FILE}"
+# -*- mode: Python -*-
+
+yaml_file = "../../cluster-api-addon-provider-helm/config/samples/calico-cni.yaml"
+k8s_yaml(yaml_file)
+
+# Create k8s resource.
+k8s_resource(objects=['calico-cni:helmchartproxy'], labels = ['CAAPH.helmchartproxy'], resource_deps = ['caaph_controller','uncategorized'],new_name='calico-cni')
+EOF


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If CNI is not installed, the sample HelmChartProxy of nginx-ingress will not work, so I want to install CNI automatically.
Registering HelmChartProxy of calico as a Tilt resource, developers will no longer have to worry about CNI.

Additions and modifications
- `develop.md`: Add a calico auto-install configuration to the development docs.
- `calico-cni.yaml`: Modify a HelmChartProxy manifest of calico to target all workload clusters.
- `setup-calico-autoinstallation.sh`: Create a shell script to register HelmChartProxy manifest of calico as a Tilt resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8
