### PR TITLE
Fix nil pointer issue when trying to check if a Helm release exists

### DIFF
--- a/internal/helm_operations.go
+++ b/internal/helm_operations.go
@@ -113,12 +113,16 @@ func InstallOrUpgradeHelmRelease(ctx context.Context, kubeconfig string, spec ad
 	// historyClient.Max = 1
 	// if _, err := historyClient.Run(spec.ReleaseName); err == helmDriver.ErrReleaseNotFound {
 	existingRelease, err := GetHelmRelease(ctx, kubeconfig, spec)
-	if err == helmDriver.ErrReleaseNotFound {
-		release, err := InstallHelmRelease(ctx, kubeconfig, spec)
-		if err != nil {
-			return nil, false, err
+	if err != nil {
+		if err == helmDriver.ErrReleaseNotFound {
+			release, err := InstallHelmRelease(ctx, kubeconfig, spec)
+			if err != nil {
+				return nil, false, err
+			}
+			return release, true, nil
 		}
-		return release, true, nil
+
+		return nil, false, err
 	}
 
 	return UpgradeHelmReleaseIfChanged(ctx, kubeconfig, spec, existingRelease)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: If we have an error from getting a Helm release and it's not an `ErrReleaseNotFound`, return the error to requeue. Before, we were assuming that the error must be an `ErrReleaseNotFound`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #19 
