### PR TITLE
:book: DOCS: Fix remote repo url

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -23,7 +23,7 @@ Create a management cluster using kind and then create a workload cluster runnin
 Run the following command to clone the CAAPH repository into your Go src folder:
 
 ```bash
-$ git clone git@github.com:Jont828/cluster-api-addon-provider-helm.git ${GOPATH}/src/cluster-api-addon-provider-helm
+$ git clone git@github.com:kubernetes-sigs/cluster-api-addon-provider-helm.git ${GOPATH}/src/cluster-api-addon-provider-helm
 ```
 
 ### 4. Install CAAPH to the management cluster


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

Nit fix while going through the quick-start. Change the repo url to the new location under kuberentes-sigs
