### PR TITLE
:seedling: Fix registry URL, image name, and job scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,11 @@ GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
 PROD_REGISTRY ?= registry.k8s.io/cluster-api
 
-STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api
-STAGING_BUCKET ?= artifacts.k8s-staging-cluster-api.appspot.com
+STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api-helm
+STAGING_BUCKET ?= artifacts.k8s-staging-cluster-api-helm.appspot.com
 
 # core
-IMAGE_NAME ?= cluster-api-controller
+IMAGE_NAME ?= cluster-api-helm-controller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 
 # kind
@@ -479,7 +479,7 @@ release-staging-nightly: ## Tag and push container images to the staging bucket.
 	$(MAKE) manifest-modification-dev REGISTRY=$(STAGING_REGISTRY) RELEASE_TAG=$(NEW_RELEASE_ALIAS_TAG)
 	## Build the dev manifests
 	$(MAKE) release-manifests-dev
-	# Example manifest location: artifacts.k8s-staging-cluster-api.appspot.com/components/nightly_main_20210121/bootstrap-components.yaml
+	# Example manifest location: artifacts.k8s-staging-cluster-api-helm.appspot.com/components/nightly_main_20210121/bootstrap-components.yaml
 	gsutil cp $(RELEASE_DIR)/* gs://$(STAGING_BUCKET)/components/$(NEW_RELEASE_ALIAS_TAG)
 
 .PHONY: release-alias-tag

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,6 +25,10 @@ bases:
 # - ../prometheus
 
 patchesStrategicMerge:
+# Provide customizable hook for make targets.
+- manager_image_patch.yaml
+- manager_pull_policy.yaml
+
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
@@ -72,3 +76,6 @@ vars:
     kind: Service
     version: v1
     name: webhook-service
+
+configurations:
+  - kustomizeconfig.yaml

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+varReference:
+- kind: Deployment
+  path: spec/template/spec/volumes/secret/secretName

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-cluster-api/cluster-api-helm-controller:latest
+        name: manager

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: Always

--- a/config/samples/metallb.yaml
+++ b/config/samples/metallb.yaml
@@ -8,9 +8,4 @@ spec:
       MetalLBChart: enabled
   repoURL: https://metallb.github.io/metallb
   chartName: metallb
-  namespace: metallb-system
   releaseName: metallb
-  valuesTemplate: |
-    speaker:
-      nodeSelector:
-        kubernetes.io/os: "linux"

--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -53,16 +53,11 @@ chmod +x ${TOOL_BIN}/trivy
 rm ${TOOL_BIN}/trivy.tar.gz
 
 # Builds all the container images to be scanned and cleans up changes to ./*manager_image_patch.yaml ./*manager_pull_policy.yaml.
-make REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent TAG=dev docker-build
+make REGISTRY=gcr.io/k8s-staging-cluster-api-helm PULL_POLICY=IfNotPresent TAG=dev docker-build
 make clean-release-git
 
 # Scan the images
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/clusterctl-"${GO_ARCH}":dev && R1=$? || R1=$?
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/test-extension-"${GO_ARCH}":dev && R2=$? || R2=$?
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-"${GO_ARCH}":dev && R3=$? || R3=$?
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-"${GO_ARCH}":dev && R4=$? || R4=$?
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/cluster-api-controller-"${GO_ARCH}":dev && R5=$? || R5=$?
-${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/capd-manager-"${GO_ARCH}":dev && R6=$? || R6=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api-helm/cluster-api-helm-controller-"${GO_ARCH}":dev && R5=$? || R5=$?
 
 echo ""
 BRed='\033[1;31m'

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -33,7 +33,8 @@ version::get_version_vars() {
 
     # stolen from k8s.io/hack/lib/version.sh
     # Use git describe to find the version based on annotated tags.
-    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
+    # Add --tags parameter to include lightweight tags.
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
         # This translates the "git describe" to an actual semver.org
         # compatible semantic version that looks something like this:
         #   v1.1.0-alpha.0.6+84c76d1142ea4d

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -22,7 +22,7 @@ capi:buildDockerImages () {
   # please ensure the generated image name matches image names used in the E2E_CONF_FILE;
   # also the same settings must be set in Makefile, docker-build-e2e target.
   ARCH="$(go env GOARCH)"
-  export REGISTRY=gcr.io/k8s-staging-cluster-api
+  export REGISTRY=gcr.io/k8s-staging-cluster-api-helm
   export TAG=dev
   export ARCH
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Fix registry URL, image name, and job scripts which removed references to CAPI images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
