### PR TITLE
🌱 Add deployment make target and files for GitHub release actions

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+# - manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,12 +5,7 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- files:
+- name: manager-config
+  files:
   - controller_manager_config.yaml
-  name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: jont828/cluster-api-addon-provider-helm
-  newTag: latest
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,10 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+releaseSeries:
+  - major: 0
+    minor: 1
+    contract: v1beta1

--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -1,6 +1,6 @@
 name: helm
 config:
-  image: jont828/cluster-api-addon-provider-helm:latest
+  image: gcr.io/k8s-staging-cluster-api-helm/cluster-api-helm-controller
   live_reload_deps:
     - main.go
     - go.mod


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds make targets to install, uninstall, deploy, and undeploy to a kind cluster. Also removes references to the Docker repo `jont828` and replaces it with the gcr staging repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
