### PR TITLE
🐛 Retry upgrades on failed releases and fix status and requeue bug

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -52,6 +52,9 @@ const (
 	// PreparingToHelmInstallReason indicates that the HelmReleaseProxy is preparing to install the Helm release.
 	PreparingToHelmInstallReason = "PreparingToHelmInstall"
 
+	// HelmReleasePendingReason indicates that the HelmReleaseProxy is pending either install, upgrade, or rollback.
+	HelmReleasePendingReason = "HelmReleasePending"
+
 	// HelmInstallOrUpgradeFailedReason indicates that the HelmReleaseProxy failed to install or upgrade the Helm release.
 	HelmInstallOrUpgradeFailedReason = "HelmInstallOrUpgradeFailed"
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Fix a bug where the HelmReleaseProxy ready condition was set to true if a release was present regardless of if it was in a failed state. Now, the controller will attempt to reupgrade the failed release and return an error if it failed. This allows us to retry on a failed release with exponential backoff. The `GenerationChangedPredicate` was also added to the HelmReleaseProxy event filter to ignore updates to the metadata and status, since otherwise we would infinitely requeue as the `status.revision` field is always incremented.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #16 
