### PR TITLE
🌱 Set ClusterctlMoveHierarchyLabel on HelmChartProxy in CRD definition

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -19,6 +19,9 @@ patchesStrategicMerge:
 - patches/cainjection_in_helmreleaseproxies.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# Adds clusterctl move hierarchy label to HelmChartProxies so they can be discovered by clusterctl move.
+- patches/clusterctl_move_label_in_helmchartproxies.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/patches/clusterctl_move_label_in_helmchartproxies.yaml
+++ b/config/crd/patches/clusterctl_move_label_in_helmchartproxies.yaml
@@ -1,0 +1,8 @@
+# The following patch adds the `clusterctl.cluster.x-k8s.io/move-hierarchy` label to the HelmChartProxy CRD type.
+# Note that this label will be present on the HelmChartProxy kind, not HelmChartProxy objects themselves.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  name: helmchartproxies.addons.cluster.x-k8s.io

--- a/controllers/helmchartproxy/helmchartproxy_controller.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller.go
@@ -23,23 +23,18 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
-
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/conditions"
-	"sigs.k8s.io/cluster-api/util/patch"
-	"sigs.k8s.io/cluster-api/util/predicates"
-	// "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
-	// "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 )
 
 // HelmChartProxyReconciler reconciles a HelmChartProxy object


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Have the HelmChartProxy controller set the ClusterctlMoveHierarchyLabel on HelmChartProxies so that it will be discovered by `clusterctl move`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #103
