### PR TITLE
🐛 Fix nil pointer bug in EnableClientCache option

### DIFF
--- a/api/v1alpha1/helmchartproxy_webhook.go
+++ b/api/v1alpha1/helmchartproxy_webhook.go
@@ -23,7 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -63,9 +63,9 @@ func (p *HelmChartProxy) Default() {
 	// If 'CreateNamespace' is not specified by user, set default value to 'true'
 	if p.Spec.Options != nil {
 		if p.Spec.Options.Install == nil {
-			p.Spec.Options.Install = &HelmInstallOptions{CreateNamespace: pointer.Bool(true)}
+			p.Spec.Options.Install = &HelmInstallOptions{CreateNamespace: ptr.To(true)}
 		} else if p.Spec.Options.Install.CreateNamespace == nil {
-			p.Spec.Options.Install.CreateNamespace = pointer.Bool(true)
+			p.Spec.Options.Install.CreateNamespace = ptr.To(true)
 		}
 	}
 }

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -230,6 +230,10 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 	}
 
 	// Set the default value for EnableClientCache if it is not set
+	if helmReleaseProxy.Spec.Options == nil {
+		helmReleaseProxy.Spec.Options = &addonsv1alpha1.HelmOptions{}
+	}
+
 	if helmReleaseProxy.Spec.Options.EnableClientCache == nil {
 		helmReleaseProxy.Spec.Options.EnableClientCache = &defaultEnableClientCache
 	}

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
@@ -224,7 +224,12 @@ func (r *HelmReleaseProxyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		return ctrl.Result{}, wrappedErr
 	}
-	defer os.Remove(credentialsPath)
+
+	defer func() {
+		if err := os.Remove(credentialsPath); err != nil {
+			log.Error(err, "failed to remove credentials file in path", "credentialsPath", credentialsPath)
+		}
+	}()
 
 	log.V(2).Info("Reconciling HelmReleaseProxy", "releaseProxyName", helmReleaseProxy.Name)
 	err = r.reconcileNormal(ctx, helmReleaseProxy, client, credentialsPath, kubeconfig)

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
@@ -402,7 +402,7 @@ func TestReconcileDelete(t *testing.T) {
 				g.Expect(conditions.Has(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
 				releaseReady := conditions.Get(hrp, addonsv1alpha1.HelmReleaseReadyCondition)
 				g.Expect(releaseReady.Status).To(Equal(corev1.ConditionFalse))
-				g.Expect(releaseReady.Reason).To(Equal(addonsv1alpha1.HelmReleaseReadyCondition))
+				g.Expect(releaseReady.Reason).To(Equal(addonsv1alpha1.HelmReleaseGetFailedReason))
 				g.Expect(releaseReady.Severity).To(Equal(clusterv1.ConditionSeverityError))
 			},
 			expectedError: errInternal.Error(),

--- a/internal/helm_client.go
+++ b/internal/helm_client.go
@@ -210,7 +210,7 @@ func (c *HelmClient) InstallHelmRelease(ctx context.Context, kubeconfig string, 
 	settings.RegistryConfig = credentialsPath
 
 	enableClientCache := true
-	if spec.Options.EnableClientCache != nil {
+	if spec.Options != nil && spec.Options.EnableClientCache != nil {
 		enableClientCache = *spec.Options.EnableClientCache
 	}
 	log.V(2).Info("Creating install registry client", "enableClientCache", enableClientCache, "credentialsPath", credentialsPath)
@@ -343,7 +343,7 @@ func (c *HelmClient) UpgradeHelmReleaseIfChanged(ctx context.Context, kubeconfig
 	settings.RegistryConfig = credentialsPath
 
 	enableClientCache := true
-	if spec.Options.EnableClientCache != nil {
+	if spec.Options != nil && spec.Options.EnableClientCache != nil {
 		enableClientCache = *spec.Options.EnableClientCache
 	}
 	log.V(2).Info("Creating upgrade registry client", "enableClientCache", enableClientCache, "credentialsPath", credentialsPath)

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	hcpController "sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy"
 	hrpController "sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmreleaseproxy"
@@ -85,7 +84,7 @@ func main() {
 	}
 	flag.Parse()
 
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	ctrl.SetLogger(klog.Background())
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Fixes a bug in #136 where a nil pointer exception was occurring in constructing the HelmReleaseProxy if Helm options was left blank.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
