### PR TITLE
🐛 Bump Go version to v1.21 in GitHub actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
       with:
-        go-version: '1.19'
+        go-version: '1.21'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
       - name: generate release artifacts
         run: |
           make release

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # tag=v3.4.0
       with:
-        go-version: 1.19
+        go-version: 1.21
     - name: Run verify container script
       run: make verify-container-images


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Go version to v1.21 in GitHub actions that reference that, so it agrees with the version in go.mod. This fixes at least the dependabot/build action that is currently broken.

**Which issue(s) this PR fixes**:

N/A
