### PR TITLE
🐛 Use local kind registry by default in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,13 +396,19 @@ test-cover: ## Run unit and integration tests and generate a coverage report
 
 
 .PHONY: test-e2e
-test-e2e: ## Run "docker-build" and "docker-push" rules then run e2e tests.
+test-e2e: ## Run `docker-build` and `docker-push` rules then run e2e tests.
 	PULL_POLICY=IfNotPresent MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
 	$(MAKE) docker-build docker-push \
 	test-e2e-run
 
+.PHONY: test-e2e-local
+test-e2e-local: ## Run `docker-build` rule then run e2e tests.
+	PULL_POLICY=IfNotPresent MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \
+	$(MAKE) docker-build \
+	test-e2e-run
+
 .PHONY: test-e2e-run-skip-manifest
-test-e2e-run-skip-manifest: $(GINKGO) $(ENVSUBST) generate-e2e-templates ## Run the end-to-end tests
+test-e2e-run-skip-manifest: $(GINKGO) $(ENVSUBST) generate-e2e-templates ## Run the end-to-end tests without updating the manifest.
 	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
 	$(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) \
 		-poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) --tags=e2e --focus="$(GINKGO_FOCUS)" \
@@ -413,7 +419,7 @@ test-e2e-run-skip-manifest: $(GINKGO) $(ENVSUBST) generate-e2e-templates ## Run 
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER)
 
 .PHONY: test-e2e-run
-test-e2e-run:
+test-e2e-run: ## Run the end-to-end tests and set controller image and pull policy in the manifest.
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) TARGET_RESOURCE="./config/default/manager_image_patch.yaml"
 	$(MAKE) set-manifest-pull-policy TARGET_RESOURCE="./config/default/manager_pull_policy.yaml" PULL_POLICY=IfNotPresent
 	MANAGER_IMAGE=$(CONTROLLER_IMG)-$(ARCH):$(TAG) \

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -25,11 +25,12 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # shellcheck source=hack/ensure-go.sh
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
-export LOCAL_ONLY=${LOCAL_ONLY:-"true"}
-export USE_LOCAL_KIND_REGISTRY=${USE_LOCAL_KIND_REGISTRY:-${LOCAL_ONLY}} 
+export USE_LOCAL_KIND_REGISTRY=${USE_LOCAL_KIND_REGISTRY:-"true"} 
 export BUILD_MANAGER_IMAGE=${BUILD_MANAGER_IMAGE:-"true"}
 
-export REGISTRY=${REGISTRY:-"localhost:5000/ci-e2e"}
+if [[ "${USE_LOCAL_KIND_REGISTRY}" == "true" ]]; then
+  export REGISTRY="localhost:5000/ci-e2e"
+fi
 
 if [[ "${BUILD_MANAGER_IMAGE}" == "true" ]]; then
   defaultTag=$(date -u '+%Y%m%d%H%M%S')
@@ -42,6 +43,9 @@ export GINKGO_NODES=10
 if [[ "${BUILD_MANAGER_IMAGE}" == "false" ]]; then
   # Load an existing image, skip docker-build and docker-push.
   make test-e2e-run
+elif [[ "${USE_LOCAL_KIND_REGISTRY}" == "true" ]]; then
+  # Build an image with kind local registry, skip docker-push. REGISTRY is set to `localhost:5000/ci-e2e`. TAG is set to `$(date -u '+%Y%m%d%H%M%S')`.
+  make test-e2e-local
 else
   # Build an image and push to the registry. TAG is set to `$(date -u '+%Y%m%d%H%M%S')`.
   make test-e2e


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Fix bug where `make docker-push` fails when registry is not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
