### PR TITLE
🌱 Move CecileRobertMichon to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,6 @@ approvers:
 reviewers:
   - cluster-api-addon-helm-maintainers
   - cluster-api-addon-helm-reviewers
+
+emeritus_approvers:
+  - CecileRobertMichon

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,17 +7,15 @@ aliases:
     - neolit123
     - timothysc
   cluster-api-admins:
-    - CecileRobertMichon
+    - fabriziopandini
     - vincepri
   cluster-api-maintainers:
-    - CecileRobertMichon
     - enxebre
     - fabriziopandini
     - sbueringer
     - vincepri
   cluster-api-addon-helm-maintainers:
     - Jont828
-    - CecileRobertMichon
     - jackfrancis
   cluster-api-addon-helm-reviewers:
     - mboersma

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,6 +11,5 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 Jont828
-CecileRobertMichon
 jackfrancis
 fabriziopandini


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves @CecileRobertMichon to emeritus approvers on CAAPH 🖖🏻, and syncs up the OWNERS files with CAPZ/CAPI.

**Which issue(s) this PR fixes**:

N/A, but should stop PRs from being assigned to inactive maintainers (after other k8s clerical PRs are created...).

I'm 99% sure this is what she intended, but please LMK if I'm wrong.
