### PR TITLE
✨ Add e2e test spec to upgrade or reinstall a Helm chart on a Cluster

### DIFF
--- a/test/e2e/helm_install.go
+++ b/test/e2e/helm_install.go
@@ -25,9 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -42,15 +40,13 @@ type HelmInstallInput struct {
 }
 
 // HelmInstallSpec implements a test that verifies a Helm chart can be installed on a workload cluster. It creates a HelmChartProxy
-// resource and patches the Cluster labels such that they match the HelmChartProxy's clusterSelector. It then waits for the Helm
-// release to be deployed on the workload cluster.
+// resource and patches the Cluster labels such that they match the HelmChartProxy's clusterSelector. It then waits for the Helm release
+// to be deployed on the workload cluster and validates the release and the HelmReleaseProxy status fields.
 func HelmInstallSpec(ctx context.Context, inputGetter func() HelmInstallInput) {
 	var (
-		specName             = "helm-install"
-		input                HelmInstallInput
-		workloadClusterProxy framework.ClusterProxy
-		mgmtClient           ctrlclient.Client
-		err                  error
+		specName   = "helm-install"
+		input      HelmInstallInput
+		mgmtClient ctrlclient.Client
 	)
 
 	input = inputGetter()
@@ -62,42 +58,8 @@ func HelmInstallSpec(ctx context.Context, inputGetter func() HelmInstallInput) {
 	Expect(mgmtClient).NotTo(BeNil())
 
 	// Create HCP on management Cluster
-	Byf("Creating HelmChartProxy %s/%s", input.HelmChartProxy.Namespace, input.HelmChartProxy.Name)
+	Byf("Creating HelmChartProxy %s/%s", input.Namespace, input.HelmChartProxy.Name)
 	Expect(mgmtClient.Create(ctx, input.HelmChartProxy)).To(Succeed())
 
-	// Get Cluster from management Cluster
-	workloadCluster := &clusterv1.Cluster{}
-	key := types.NamespacedName{
-		Namespace: input.Namespace.Name,
-		Name:      input.ClusterName,
-	}
-	err = mgmtClient.Get(ctx, key, workloadCluster)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Patch cluster labels, ignore match expressions for now
-	selector := input.HelmChartProxy.Spec.ClusterSelector
-	labels := workloadCluster.Labels
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	for k, v := range selector.MatchLabels {
-		labels[k] = v
-	}
-
-	err = mgmtClient.Update(ctx, workloadCluster)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Wait for HelmReleaseProxy to be ready
-	hrpWaitInput := GetWaitForHelmReleaseProxyReadyInput(ctx, bootstrapClusterProxy, input.ClusterName, *input.HelmChartProxy, specName)
-	WaitForHelmReleaseProxyReady(ctx, hrpWaitInput, e2eConfig.GetIntervals(specName, "wait-helmreleaseproxy-ready")...)
-
-	// Get workload Cluster proxy
-	By("creating a clusterctl proxy to the workload cluster")
-	workloadClusterProxy = input.BootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
-	Expect(workloadClusterProxy).NotTo(BeNil())
-
-	// Wait for Helm release on workload cluster to have stauts = deployed
-	releaseWaitInput := GetWaitForHelmReleaseDeployedInput(ctx, workloadClusterProxy, input.HelmChartProxy.Spec.ReleaseName, input.Namespace.Name, specName)
-	WaitForHelmReleaseDeployed(ctx, releaseWaitInput, e2eConfig.GetIntervals(specName, "wait-helm-release-deployed")...)
+	EnsureHelmReleaseInstallOrUpgrade(ctx, specName, input.BootstrapClusterProxy, &input, nil)
 }

--- a/test/e2e/helm_upgrade.go
+++ b/test/e2e/helm_upgrade.go
@@ -1,0 +1,88 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+// HelmUpgradeInput specifies the input for updating or reinstalling a Helm chart on a workload cluster and verifying that it was successful.
+type HelmUpgradeInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	HelmChartProxy        *addonsv1alpha1.HelmChartProxy // Note: Only the Spec field is used.
+	ExpectedRevision      int
+}
+
+// HelmUpgradeSpec implements a test that verifies a Helm chart can be either updated or reinstalled on a workload cluster, depending on
+// if an immutable field has changed. It takes a HelmChartProxy resource and updates ONLY the spec field and patches the Cluster labels
+// such that they match the HelmChartProxy's clusterSelector. It then waits for the Helm release to be deployed on the workload cluster
+// and validates the release and the HelmReleaseProxy status fields.
+func HelmUpgradeSpec(ctx context.Context, inputGetter func() HelmUpgradeInput) {
+	var (
+		specName   = "helm-upgrade"
+		input      HelmUpgradeInput
+		mgmtClient ctrlclient.Client
+		err        error
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the management cluster")
+	mgmtClient = input.BootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	// Get existing HCP from management Cluster
+	existing := &addonsv1alpha1.HelmChartProxy{}
+	key := types.NamespacedName{
+		Namespace: input.HelmChartProxy.Namespace,
+		Name:      input.HelmChartProxy.Name,
+	}
+	err = mgmtClient.Get(ctx, key, existing)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Patch HCP on management Cluster
+	Byf("Patching HelmChartProxy %s/%s", existing.Namespace, existing.Name)
+	patchHelper, err := patch.NewHelper(existing, mgmtClient)
+	Expect(err).ToNot(HaveOccurred())
+
+	existing.Spec = input.HelmChartProxy.Spec
+	input.HelmChartProxy = existing
+
+	Eventually(func() error {
+		return patchHelper.Patch(ctx, existing)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to patch HelmChartProxy %s", klog.KObj(existing))
+
+	EnsureHelmReleaseInstallOrUpgrade(ctx, specName, input.BootstrapClusterProxy, nil, &input)
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds an additional spec to update a HelmChartProxy and verify that the revision and values have successfully changed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #172
