### PR TITLE
:bug: Add namespace when listing HelmReleaseProxies related to HelmChartProxy

### DIFF
--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -104,6 +104,7 @@ func (r *HelmChartProxyReconciler) getExistingHelmReleaseProxy(ctx context.Conte
 	helmReleaseProxyList := &addonsv1alpha1.HelmReleaseProxyList{}
 
 	listOpts := []client.ListOption{
+		client.InNamespace(helmChartProxy.Namespace),
 		client.MatchingLabels{
 			clusterv1.ClusterNameLabel:             cluster.Name,
 			addonsv1alpha1.HelmChartProxyLabelName: helmChartProxy.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
HelmReleaseProxy should be created when there is a HelmChartProxy / Cluster with the same name in a different namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #176 
