### PR TITLE
🌱 Replace deprecated call to klogr.NewWithOptions

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy"
 	"sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmreleaseproxy"
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func() {
 	klog.InitFlags(&fs)
 	err := fs.Set("v", "2")
 	Expect(err).NotTo(HaveOccurred())
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the deprecated call to [`klogr.NewWithOptions()`](https://pkg.go.dev/k8s.io/klog/v2/klogr#pkg-functions) with the recommended API `textlogger.NewLogger`.

This deprecation has been failing the linter in PR #180, but curiously, no where else that I've seen. Regardless, it is an actual deprecation.

```
  Running [/home/runner/golangci-lint-1.54.1-linux-amd64/golangci-lint run --out-format=github-actions --timeout=5m] in [] ...
  Error: SA1019: klogr.NewWithOptions is deprecated: FormatSerialize is out-dated. For FormatKlog, use textlogger.NewLogger instead.  (staticcheck)
```

**Which issue(s) this PR fixes**:

See #180