### PR TITLE
🌱 Bump CAPI versions in e2e config

### DIFF
--- a/test/e2e/config/helm.yaml
+++ b/test/e2e/config/helm.yaml
@@ -3,22 +3,22 @@ managementClusterName: caaph-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.6.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.6.3
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.6.3
     loadBehavior: tryLoad
   # Note: This pulls the CAPD image from the staging repo instead of the official registry.
-  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.6.1
+  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.6.3
     loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.5.0 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/core-components.yaml"
+  - name: v1.5.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -26,8 +26,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/core-components.yaml
+  - name: v1.6.3
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/core-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -40,8 +40,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.5.0 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/bootstrap-components.yaml"
+  - name: v1.5.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -49,8 +49,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/bootstrap-components.yaml
+  - name: v1.6.3
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/bootstrap-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -62,8 +62,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.5.0 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/control-plane-components.yaml"
+  - name: v1.5.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -71,8 +71,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.6.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/control-plane-components.yaml
+  - name: v1.6.3
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/control-plane-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -84,8 +84,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v1.5.0 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/infrastructure-components-development.yaml"
+  - name: v1.5.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.7/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -95,8 +95,8 @@ providers:
     - sourcePath: "${PWD}/test/e2e/data/shared/v1beta1/metadata.yaml"
     - sourcePath: "${PWD}/test/e2e/data/addons-helm/v1.5/cluster-template.yaml"
       targetName: "cluster-template.yaml"
-  - name: "v1.6.1" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.1/infrastructure-components-development.yaml"
+  - name: "v1.6.3" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.3/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -165,7 +165,7 @@ variables:
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
-  OLD_CAPI_UPGRADE_VERSION: "v1.5.0"
+  OLD_CAPI_UPGRADE_VERSION: "v1.5.7"
   OLD_PROVIDER_UPGRADE_VERSION: "v0.1.1-alpha.0"
 
 intervals:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the versions of CAPI in the e2e test configuration to the latest patches available.

**Which issue(s) this PR fixes**:

None, but see #191 and #193
