### PR TITLE
🌱 add explicit securityContext the CAAPH deployment

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,14 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          runAsUser: 65532
+          runAsGroup: 65532
         resources:
           limits:
             cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,8 +24,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      # securityContext:
-      #   runAsNonRoot: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - args:
           - --leader-elect
@@ -35,8 +37,14 @@ spec:
           image: controller:latest
           imagePullPolicy: Always
           name: manager
-          # securityContext:
-          #   allowPrivilegeEscalation: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
           ports:
             - containerPort: 9440
               name: healthz


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds explicit security context best practices to the Deployment/pods for CAAPH. values have been taken from the [Cluster API Controller deployment](https://github.com/kubernetes-sigs/cluster-api/blob/main/config/manager/manager.yaml#L57-L64) securityContexts
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
