### PR TITLE
🐛 Fix TestReconcileForCluster unit test

### DIFF
--- a/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
@@ -313,7 +313,7 @@ func TestReconcileForCluster(t *testing.T) {
 		},
 		{
 			name:                          "do not reconcile for a paused cluster",
-			helmChartProxy:                fakeReinstallHelmChartProxy,
+			helmChartProxy:                fakeHelmChartProxy1,
 			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
 			cluster:                       fakeClusterPaused,
 			expectHelmReleaseProxyToExist: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `TestReconcileForCluster` intermittent failure by not re-using a test artifact after it has conditions added to it. It's not ideal that we mutate some of these test resources, but I'm avoiding a larger refactor here to get the tests passing reliably.

**Which issue(s) this PR fixes**:

Fixes #220 

Thanks to @dmvolod for pointing out that `go test -count=2 ./controllers/helmchartproxy/...` makes this bug occur all the time. This allowed me to debug it. (Removing `t.Parallel()` also triggers the failure.)
