### PR TITLE
🌱 Bump CAPI to v1.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	k8s.io/client-go v0.29.3
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
-	sigs.k8s.io/cluster-api v1.7.1
-	sigs.k8s.io/cluster-api/test v1.7.1
+	sigs.k8s.io/cluster-api v1.7.2
+	sigs.k8s.io/cluster-api/test v1.7.2
 	sigs.k8s.io/controller-runtime v0.17.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -731,10 +731,10 @@ oras.land/oras-go v1.2.5-0.20240123054708-2afb6872ee1a h1:CBzjCQjdoYMAzWL+ExkMtq
 oras.land/oras-go v1.2.5-0.20240123054708-2afb6872ee1a/go.mod h1:9/sEWiU8gaqBtkTmrFw4OdaDAZT87SZ7c+KZ3y6fmcE=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0/go.mod h1:VHVDI/KrK4fjnV61bE2g3sA7tiETLn8sooImelsCx3Y=
-sigs.k8s.io/cluster-api v1.7.1 h1:JkMAbAMzBM+WBHxXLTJXTiCisv1PAaHRzld/3qrmLYY=
-sigs.k8s.io/cluster-api v1.7.1/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
-sigs.k8s.io/cluster-api/test v1.7.1 h1:QDru2586ZjIFBTW1Z7VVXVtauzR/yANm4tglUNLm9iE=
-sigs.k8s.io/cluster-api/test v1.7.1/go.mod h1:yG0g5Mdq73fMn9JP4akgRQPSne973L+Qx6iVH+LjtSM=
+sigs.k8s.io/cluster-api v1.7.2 h1:bRE8zoao7ajuLC0HijqfZVcubKQCPlZ04HMgcA53FGE=
+sigs.k8s.io/cluster-api v1.7.2/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
+sigs.k8s.io/cluster-api/test v1.7.2 h1:muacGu5G/DGz2uTv3CUxml2QLi8fxbIra4CxA2S31KE=
+sigs.k8s.io/cluster-api/test v1.7.2/go.mod h1:yG0g5Mdq73fMn9JP4akgRQPSne973L+Qx6iVH+LjtSM=
 sigs.k8s.io/controller-runtime v0.17.3 h1:65QmN7r3FWgTxDMz9fvGnO1kbf2nu+acg9p2R9oYYYk=
 sigs.k8s.io/controller-runtime v0.17.3/go.mod h1:N0jpP5Lo7lMTF9aL56Z/B2oWBJjey6StQM0jRbKQXtY=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/test/e2e/config/helm.yaml
+++ b/test/e2e/config/helm.yaml
@@ -3,22 +3,22 @@ managementClusterName: caaph-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.2
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.1
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.2
     loadBehavior: tryLoad
   # Note: This pulls the CAPD image from the staging repo instead of the official registry.
-  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.7.1
+  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.7.2
     loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.5.8 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.8/core-components.yaml"
+  - name: v1.6.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.5/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -26,8 +26,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/core-components.yaml
+  - name: v1.7.2
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/core-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -40,8 +40,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.5.8 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.8/bootstrap-components.yaml"
+  - name: v1.6.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.5/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -49,8 +49,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/bootstrap-components.yaml
+  - name: v1.7.2
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/bootstrap-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -62,8 +62,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.5.8 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.8/control-plane-components.yaml"
+  - name: v1.6.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.5/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -71,8 +71,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.1
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/control-plane-components.yaml
+  - name: v1.7.2
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/control-plane-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -84,8 +84,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v1.5.8 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.8/infrastructure-components-development.yaml"
+  - name: v1.6.5 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.5/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -95,8 +95,8 @@ providers:
     - sourcePath: "${PWD}/test/e2e/data/shared/v1beta1/metadata.yaml"
     - sourcePath: "${PWD}/test/e2e/data/addons-helm/v1.5/cluster-template.yaml"
       targetName: "cluster-template.yaml"
-  - name: "v1.7.1" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.1/infrastructure-components-development.yaml"
+  - name: "v1.7.2" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.2/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -165,7 +165,7 @@ variables:
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
-  OLD_CAPI_UPGRADE_VERSION: "v1.5.8"
+  OLD_CAPI_UPGRADE_VERSION: "v1.6.5"
   OLD_PROVIDER_UPGRADE_VERSION: "v0.1.1-alpha.1"
 
 intervals:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates CAPI to [v1.7.2](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.2) and all that entails. Also bumps the old version used in the `clusterctl` upgrade test to v1.6.5.

**Which issue(s) this PR fixes**:

N/A

/kind cleanup