### PR TITLE
:bug: Fix e2e test by using quay.io for images

### DIFF
--- a/test/e2e/config/helm.yaml
+++ b/test/e2e/config/helm.yaml
@@ -191,6 +191,7 @@ intervals:
   default/wait-helmreleaseproxy-ready: ["10m", "10s"]
   default/wait-helm-release: ["10m", "10s"]
   default/wait-helm-release-deployed: ["10m", "10s"]
+  default/wait-delete-helmreleaseproxy: ["3m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]
   node-drain/wait-control-plane: ["15m", "10s"]
   node-drain/wait-machine-deleted: ["2m", "10s"]

--- a/test/e2e/data/addons-helm/v1.5/bases/calico.yaml
+++ b/test/e2e/data/addons-helm/v1.5/bases/calico.yaml
@@ -8,7 +8,6 @@ spec:
       cni: calico
   repoURL: https://docs.tigera.io/calico/charts
   chartName: tigera-operator
-  # version: ${CALICO_VERSION}
   releaseName: projectcalico
   namespace: tigera-operator
   valuesTemplate: |
@@ -18,14 +17,12 @@ spec:
       calicoNetwork:
         bgp: Disabled
         mtu: 1350
-        ipPools:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
-      registry: mcr.microsoft.com/oss
+      registry: quay.io/
     # Image and registry configuration for the tigera/operator pod.
     tigeraOperator:
-      image: tigera/operator
-      registry: mcr.microsoft.com/oss
+      registry: quay.io
     calicoctl:
-      image: mcr.microsoft.com/oss/calico/ctl
+      image: quay.io/calico/ctl

--- a/test/e2e/data/addons-helm/v1.5/cluster-template.yaml
+++ b/test/e2e/data/addons-helm/v1.5/cluster-template.yaml
@@ -17,17 +17,15 @@ spec:
       calicoNetwork:
         bgp: Disabled
         mtu: 1350
-        ipPools:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
-      registry: mcr.microsoft.com/oss
+      registry: quay.io/
     # Image and registry configuration for the tigera/operator pod.
     tigeraOperator:
-      image: tigera/operator
-      registry: mcr.microsoft.com/oss
+      registry: quay.io
     calicoctl:
-      image: mcr.microsoft.com/oss/calico/ctl
+      image: quay.io/calico/ctl
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/addons-helm/v1beta1/bases/calico.yaml
+++ b/test/e2e/data/addons-helm/v1beta1/bases/calico.yaml
@@ -17,14 +17,12 @@ spec:
       calicoNetwork:
         bgp: Disabled
         mtu: 1350
-        ipPools:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
-      registry: mcr.microsoft.com/oss
+      registry: quay.io/
     # Image and registry configuration for the tigera/operator pod.
     tigeraOperator:
-      image: tigera/operator
-      registry: mcr.microsoft.com/oss
+      registry: quay.io
     calicoctl:
-      image: mcr.microsoft.com/oss/calico/ctl
+      image: quay.io/calico/ctl

--- a/test/e2e/data/addons-helm/v1beta1/cluster-template-upgrades.yaml
+++ b/test/e2e/data/addons-helm/v1beta1/cluster-template-upgrades.yaml
@@ -17,17 +17,15 @@ spec:
       calicoNetwork:
         bgp: Disabled
         mtu: 1350
-        ipPools:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
-      registry: mcr.microsoft.com/oss
+      registry: quay.io/
     # Image and registry configuration for the tigera/operator pod.
     tigeraOperator:
-      image: tigera/operator
-      registry: mcr.microsoft.com/oss
+      registry: quay.io
     calicoctl:
-      image: mcr.microsoft.com/oss/calico/ctl
+      image: quay.io/calico/ctl
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster

--- a/test/e2e/data/addons-helm/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/addons-helm/v1beta1/cluster-template.yaml
@@ -17,17 +17,15 @@ spec:
       calicoNetwork:
         bgp: Disabled
         mtu: 1350
-        ipPools:
         ipPools:{{range $i, $cidr := .Cluster.spec.clusterNetwork.pods.cidrBlocks }}
         - cidr: {{ $cidr }}
           encapsulation: VXLAN{{end}}
-      registry: mcr.microsoft.com/oss
+      registry: quay.io/
     # Image and registry configuration for the tigera/operator pod.
     tigeraOperator:
-      image: tigera/operator
-      registry: mcr.microsoft.com/oss
+      registry: quay.io
     calicoctl:
-      image: mcr.microsoft.com/oss/calico/ctl
+      image: quay.io/calico/ctl
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
Images are not automatically published to MCR on each Calico release to use quay.io instead, where Calico images are pushed as part of the Calico release process (see https://github.com/projectcalico/calico/blob/master/hack/release/pkg/builder/builder.go#L29-L37).