### PR TITLE
:bug: Fix OCI client configuration logic

### DIFF
--- a/internal/helm_client.go
+++ b/internal/helm_client.go
@@ -254,7 +254,7 @@ func (c *HelmClient) InstallHelmRelease(ctx context.Context, restConfig *rest.Co
 
 // newDefaultRegistryClient creates registry client object with default config which can be used to install/upgrade helm charts.
 func newDefaultRegistryClient(credentialsPath string, enableCache bool, caFilePath string, insecureSkipTLSVerify bool) (*registry.Client, error) {
-	if caFilePath == "" || !insecureSkipTLSVerify {
+	if caFilePath == "" && !insecureSkipTLSVerify {
 		opts := []registry.ClientOption{
 			registry.ClientOptDebug(true),
 			registry.ClientOptEnableCache(enableCache),


### PR DESCRIPTION
This commit fixes the logic deciding to create a TLS client for OCI
charts.

The existing code was creating a non-TLS configured client if either the CA file
was unspecified or if `insecureSkipTLSVerify` was set to false. If a CA
file was specified then `insecureSkipTLSVerify` is always false, which meant
that a non-TLS client was always created, causing cert validation
failures if the OCI registry is served over TLS.

This commit changes the logic to create a non-TLS configured client if
both CA file is unset AND `insecureSkipTLSVerify` is false.
