### PR TITLE
:bug:  pointer checks if user doesn't specify CASecret

### DIFF
--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -237,7 +237,7 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 
 	helmReleaseProxy.Spec.TLSConfig = helmChartProxy.Spec.TLSConfig
 
-	if helmReleaseProxy.Spec.TLSConfig != nil {
+	if helmReleaseProxy.Spec.TLSConfig != nil && helmReleaseProxy.Spec.TLSConfig.CASecretRef != nil {
 		// If the namespace is not set, set it to the namespace of the HelmChartProxy
 		if helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace == "" {
 			helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace = helmChartProxy.Namespace

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
@@ -1010,6 +1010,85 @@ func TestConstructHelmReleaseProxy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "construct helm release proxy with insecure TLS",
+			existing: nil,
+			helmChartProxy: &addonsv1alpha1.HelmChartProxy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: addonsv1alpha1.GroupVersion.String(),
+					Kind:       "HelmChartProxy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: addonsv1alpha1.HelmChartProxySpec{
+					ReleaseName:      "test-release-name",
+					ChartName:        "test-chart-name",
+					RepoURL:          "https://test-repo-url",
+					ReleaseNamespace: "test-release-namespace",
+					Options: addonsv1alpha1.HelmOptions{
+						EnableClientCache: true,
+						Timeout: &metav1.Duration{
+							Duration: 10 * time.Minute,
+						},
+					},
+					TLSConfig: &addonsv1alpha1.TLSConfig{
+						InsecureSkipTLSVerify: true,
+					},
+				},
+			},
+			parsedValues: "test-parsed-values",
+			cluster: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "Cluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+			},
+			expected: &addonsv1alpha1.HelmReleaseProxy{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-chart-name-test-cluster-",
+					Namespace:    "test-namespace",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         addonsv1alpha1.GroupVersion.String(),
+							Kind:               "HelmChartProxy",
+							Name:               "test-hcp",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+					Labels: map[string]string{
+						clusterv1.ClusterNameLabel:             "test-cluster",
+						addonsv1alpha1.HelmChartProxyLabelName: "test-hcp",
+					},
+				},
+				Spec: addonsv1alpha1.HelmReleaseProxySpec{
+					ClusterRef: corev1.ObjectReference{
+						APIVersion: clusterv1.GroupVersion.String(),
+						Kind:       "Cluster",
+						Name:       "test-cluster",
+					},
+					ReleaseName:      "test-release-name",
+					ChartName:        "test-chart-name",
+					RepoURL:          "https://test-repo-url",
+					ReleaseNamespace: "test-release-namespace",
+					Values:           "test-parsed-values",
+					Options: addonsv1alpha1.HelmOptions{
+						EnableClientCache: true,
+						Timeout: &metav1.Duration{
+							Duration: 10 * time.Minute,
+						},
+					},
+					TLSConfig: &addonsv1alpha1.TLSConfig{
+						InsecureSkipTLSVerify: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
@@ -399,7 +399,9 @@ func (r *HelmReleaseProxyReconciler) getCredentials(ctx context.Context, helmRel
 // getCAFile fetches the CA certificate from a Secret and writes it to a temporary file, returning the path to the temporary file.
 func (r *HelmReleaseProxyReconciler) getCAFile(ctx context.Context, helmReleaseProxy *addonsv1alpha1.HelmReleaseProxy) (string, error) {
 	caFilePath := ""
-	if helmReleaseProxy.Spec.TLSConfig != nil && helmReleaseProxy.Spec.TLSConfig.CASecretRef.Name != "" {
+	if helmReleaseProxy.Spec.TLSConfig != nil &&
+		helmReleaseProxy.Spec.TLSConfig.CASecretRef != nil &&
+		helmReleaseProxy.Spec.TLSConfig.CASecretRef.Name != "" {
 		// By default, the secret is in the same namespace as the HelmReleaseProxy
 		if helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace == "" {
 			helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace = helmReleaseProxy.Namespace


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes a nil pointer panic if a user does not specify CASecretRef in TLSConfig.

```
I0603 14:53:15.290968       1 controller.go:115] "Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference" controller="helmchartproxy" controllerGroup="addons.cluster.x-k8s.io" controllerKind="HelmChartProxy" HelmChartProxy="default/```" namespace="default" name="node-feature-discovery-docker-cluster-cilium-helm-addon5" reconcileID="8498516d-cf78-49bb-bf2a-0ee6b355f62e"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x20d81cd]

goroutine 268 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x24a6b00?, 0x4314de0?})
	runtime/panic.go:914 +0x21f
sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy.constructHelmReleaseProxy(0x0, 0xc00088e900, {0xc0004d8d20, 0x1c5}, 0xc000aaf460)
	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy/helmchartproxy_controller_phases.go:242 +0x84d
sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy.(*HelmChartProxyReconciler).createOrUpdateHelmReleaseProxy(0xc0002a6690, {0x2ce2120, 0xc000ae4870}, 0x0, 0x12?, 0xc000bcf460, {0xc0004d8d20, 0x1c5})
	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy/helmchartproxy_controller_phases.go:144 +0xb3
sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy.(*HelmChartProxyReconciler).reconcileForCluster(_, {_, _}, _, {{{0x21f74a1, 0x7}, {0xc000a16078, 0x18}}, {{0xc0005c1140, 0x21}, ...}, ...})
	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy/helmchartproxy_controller_phases.go:98 +0x71e
sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy.(*HelmChartProxyReconciler).reconcileNormal(0x28edbe7?, {0x2ce2120, 0xc000ae4870}, 0xc00088e900, {0xc000a3a9c0, 0x1, 0x1}, {0x43ad560, 0x0, 0x0})
	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy/helmchartproxy_controller.go:221 +0x2f8
sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy.(*HelmChartProxyReconciler).Reconcile(0xc0002a6690, {0x2ce2120?, 0xc000ae4870}, {{{0xc0000bd4a0, 0x7}, {0xc000a966c0, 0x38}}})
	sigs.k8s.io/cluster-api-addon-provider-helm/controllers/helmchartproxy/helmchartproxy_controller.go:188 +0x106c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2ce8638?, {0x2ce2120?, 0xc000ae4870?}, {{{0xc0000bd4a0?, 0xb?}, {0xc000a966c0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0005f20a0, {0x2ce2158, 0xc000979c20}, {0x25e5020?, 0xc0007dafe0?})
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316 +0x3cc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0005f20a0, {0x2ce2158, 0xc000979c20})
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266 +0x1af
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 178
	sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:223 +0x565
```

This is the yaml that is giving the issue. 

```yaml
$ k get hcp node-feature-discovery-docker-cluster-cilium-helm-addon5 -o yaml
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: HelmChartProxy
metadata:
  creationTimestamp: "2024-06-03T14:52:58Z"
  finalizers:
  - helmchartproxy.addons.cluster.x-k8s.io
  generation: 1
  name: node-feature-discovery-docker-cluster-cilium-helm-addon5
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: docker-cluster-cilium-helm-addon5
    uid: ef487087-bf8a-44d1-8286-a05174cd8ecb
  resourceVersion: "2551"
  uid: 9bd0db75-96b2-43ed-b628-3460f60afae2
spec:
  chartName: node-feature-discovery
  clusterSelector:
    matchLabels:
      cluster.x-k8s.io/cluster-name: docker-cluster-cilium-helm-addon5
  namespace: node-feature-discovery
  options:
    enableClientCache: false
    install:
      createNamespace: true
    timeout: 10m0s
    upgrade:
      maxHistory: 10
  releaseName: node-feature-discovery
  repoURL: oci://mindthegap.default.svc/charts
  tlsConfig:
    insecureSkipTLSVerify: true
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
