### PR TITLE
🌱 Bump CAPI to v1.7.4 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	k8s.io/component-base v0.29.3
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
-	sigs.k8s.io/cluster-api v1.7.3
-	sigs.k8s.io/cluster-api/test v1.7.3
+	sigs.k8s.io/cluster-api v1.7.4
+	sigs.k8s.io/cluster-api/test v1.7.4
 	sigs.k8s.io/controller-runtime v0.17.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -719,10 +719,10 @@ oras.land/oras-go v1.2.5-0.20240123054708-2afb6872ee1a h1:CBzjCQjdoYMAzWL+ExkMtq
 oras.land/oras-go v1.2.5-0.20240123054708-2afb6872ee1a/go.mod h1:9/sEWiU8gaqBtkTmrFw4OdaDAZT87SZ7c+KZ3y6fmcE=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2SGwkQasmbeqDo8th5wOBA5h/AjTKA4I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0/go.mod h1:VHVDI/KrK4fjnV61bE2g3sA7tiETLn8sooImelsCx3Y=
-sigs.k8s.io/cluster-api v1.7.3 h1:DsSRxsA+18jxLqPAo29abZ9kOPK1/xwhSuQb/MROzSs=
-sigs.k8s.io/cluster-api v1.7.3/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
-sigs.k8s.io/cluster-api/test v1.7.3 h1:Nl1IOF03MZzjr6x45IJOFWlV4cNHpJ45qsn3A+1Tf98=
-sigs.k8s.io/cluster-api/test v1.7.3/go.mod h1:KbK8+zZEmSopCm6IGd9Vk+573sQ+HL6hnPvqelJEYi4=
+sigs.k8s.io/cluster-api v1.7.4 h1:gT9WGbLXKE19pNR6s/cTLRqK2G0EbwxxQrUrw7/w5P4=
+sigs.k8s.io/cluster-api v1.7.4/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
+sigs.k8s.io/cluster-api/test v1.7.4 h1:yBeWaQoPcAbLMF/ddgz0IWJiFgfJe+QfZJ4QWexMVOw=
+sigs.k8s.io/cluster-api/test v1.7.4/go.mod h1:KbK8+zZEmSopCm6IGd9Vk+573sQ+HL6hnPvqelJEYi4=
 sigs.k8s.io/controller-runtime v0.17.3 h1:65QmN7r3FWgTxDMz9fvGnO1kbf2nu+acg9p2R9oYYYk=
 sigs.k8s.io/controller-runtime v0.17.3/go.mod h1:N0jpP5Lo7lMTF9aL56Z/B2oWBJjey6StQM0jRbKQXtY=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/test/e2e/config/helm.yaml
+++ b/test/e2e/config/helm.yaml
@@ -3,22 +3,22 @@ managementClusterName: caaph-e2e
 images:
   - name: ${MANAGER_IMAGE}
     loadBehavior: mustLoad
-  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.3
+  - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.7.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.3
+  - name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.7.4
     loadBehavior: tryLoad
-  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.3
+  - name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.7.4
     loadBehavior: tryLoad
   # Note: This pulls the CAPD image from the staging repo instead of the official registry.
-  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.7.3
+  - name: gcr.io/k8s-staging-cluster-api/capd-manager:v1.7.4
     loadBehavior: tryLoad
 
 providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.6.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.6/core-components.yaml"
+  - name: v1.6.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -26,8 +26,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.3
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/core-components.yaml
+  - name: v1.7.4
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/core-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -40,8 +40,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.6.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.6/bootstrap-components.yaml"
+  - name: v1.6.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -49,8 +49,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.3
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/bootstrap-components.yaml
+  - name: v1.7.4
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/bootstrap-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -62,8 +62,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.6.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.6/control-plane-components.yaml"
+  - name: v1.6.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -71,8 +71,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.7.3
-    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/control-plane-components.yaml
+  - name: v1.7.4
+    value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/control-plane-components.yaml
     type: url
     contract: v1beta1
     files:
@@ -84,8 +84,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v1.6.6 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.6/infrastructure-components-development.yaml"
+  - name: v1.6.7 # latest patch of earliest minor in supported v1beta1 releases; this is used for v1beta1 old --> v1beta1 latest clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.6.7/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -95,8 +95,8 @@ providers:
     - sourcePath: "${PWD}/test/e2e/data/shared/v1beta1/metadata.yaml"
     - sourcePath: "${PWD}/test/e2e/data/addons-helm/v1.5/cluster-template.yaml"
       targetName: "cluster-template.yaml"
-  - name: "v1.7.3" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/infrastructure-components-development.yaml"
+  - name: "v1.7.4" # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -165,7 +165,7 @@ variables:
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
-  OLD_CAPI_UPGRADE_VERSION: "v1.6.6"
+  OLD_CAPI_UPGRADE_VERSION: "v1.6.7"
   OLD_PROVIDER_UPGRADE_VERSION: "v0.1.1-alpha.1"
 
 intervals:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates CAPI to [v1.7.4](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.4) and all that entails. Also bumps the old version used in the `clusterctl` upgrade test to v1.6.7.

**Which issue(s) this PR fixes**:

N/A, but see #260 for prior art.

/kind cleanup