### PR TITLE
:sparkles: expose resetThenReuseValues upgrade option

### DIFF
--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -169,6 +169,10 @@ type HelmUpgradeOptions struct {
 	// +optional
 	ReuseValues bool `json:"reuseValues,omitempty"`
 
+	// ResetThenReuseValues will reset the values to the chart's built-ins then merge with user's last supplied values.
+	// +optional
+	ResetThenReuseValues bool `json:"resetThenReuseValues,omitempty"`
+
 	// Recreate will (if true) recreate pods after a rollback.
 	// +optional
 	Recreate bool `json:"recreate,omitempty"`

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -236,6 +236,11 @@ spec:
                         description: Recreate will (if true) recreate pods after a
                           rollback.
                         type: boolean
+                      resetThenReuseValues:
+                        description: ResetThenReuseValues will reset the values to
+                          the chart's built-ins then merge with user's last supplied
+                          values.
+                        type: boolean
                       resetValues:
                         description: ResetValues will reset the values to the chart's
                           built-ins rather than merging with existing.

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
@@ -243,6 +243,11 @@ spec:
                         description: Recreate will (if true) recreate pods after a
                           rollback.
                         type: boolean
+                      resetThenReuseValues:
+                        description: ResetThenReuseValues will reset the values to
+                          the chart's built-ins then merge with user's last supplied
+                          values.
+                        type: boolean
                       resetValues:
                         description: ResetValues will reset the values to the chart's
                           built-ins rather than merging with existing.

--- a/internal/helm_client.go
+++ b/internal/helm_client.go
@@ -162,6 +162,7 @@ func generateHelmUpgradeConfig(actionConfig *helmAction.Configuration, helmOptio
 	upgradeClient.Force = helmOptions.Upgrade.Force
 	upgradeClient.ResetValues = helmOptions.Upgrade.ResetValues
 	upgradeClient.ReuseValues = helmOptions.Upgrade.ReuseValues
+	upgradeClient.ResetThenReuseValues = helmOptions.Upgrade.ResetThenReuseValues
 	upgradeClient.MaxHistory = helmOptions.Upgrade.MaxHistory
 	upgradeClient.CleanupOnFail = helmOptions.Upgrade.CleanupOnFail
 


### PR DESCRIPTION
**What this PR does / why we need it**:

expose the Helm upgrade resetThenReuseValues options in CAAPH

