### PR TITLE
✨ add `VersionTemplate` support for `HelmChartProxy`

### DIFF
--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -59,6 +59,12 @@ type HelmChartProxySpec struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
+	// VersionTemplate is an inline Go template representing the version for the Helm chart. This template supports Go templating
+	// to reference fields from each selected workload Cluster and programatically create and set the version.
+	// If the Version is specified, VersionTemplate will take precedence.
+	// +optional
+	VersionTemplate string `json:"versionTemplate,omitempty"`
+
 	// ValuesTemplate is an inline YAML representing the values for the Helm chart. This YAML supports Go templating to reference
 	// fields from each selected workload Cluster and programatically create and set values.
 	// +optional

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -300,6 +300,12 @@ spec:
                   Version is the version of the Helm chart. If it is not specified, the chart will use
                   and be kept up to date with the latest version.
                 type: string
+              versionTemplate:
+                description: |-
+                  VersionTemplate is an inline Go template representing the version for the Helm chart. This template supports Go templating
+                  to reference fields from each selected workload Cluster and programatically create and set the version.
+                  If the Version is specified, VersionTemplate will take precedence.
+                type: string
             required:
             - chartName
             - clusterSelector

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -67,6 +67,7 @@ metadata:
   namespace: default
   labels:
     nginxIngressChart: enabled
+    version: 1.26
 spec:
   clusterNetwork:
     services:
@@ -105,6 +106,7 @@ spec:
     timeout: 5m
     install:
       createNamespace: true
+  versionTemplate: {{ if eq .Cluster.metadata.labels.version "1.26" }}v2{{ else }}v1{{ end }}
   valuesTemplate: |
     controller:
       name: "{{ .ControlPlane.metadata.name }}-nginx"
@@ -117,6 +119,7 @@ We use the `clusterSelector` to select the workload cluster to install the chart
 The `repoURL` and `chartName` are used to specify the chart to install.
 User shall specify chart-path `oci://repo-url/chart-name` as `repoURL: oci://repo-url` and `chartName: chart-name` in HCP CR. This format is consistent with other types of charts as well (e.g. `https://repo-url/chart-name` as `repoURL: https://repo-url` and `chartName: chart-name`).
 The `valuesTemplate` is used to specify the values to use when installing the chart. It supports Go templating, and here we set `controller.name` to the name of the selected cluster + `-nginx`. We also set `controller.nginxStatus.allowCidrs` to include the first entry in the workload cluster's pod CIDR blocks.
+The `versionTemplate` is used to specify the version of the chart to install. It supports Go templating, and here we set `metadata.labels.version` to the name of the Kubernetes version. Eventually, we can use different chart versions based on the Kubernetes versions.
 
 Helm options like `wait`, `skipCrds`, `timeout`, `waitForJobs`, etc. can be specified with `options` field as shown in above mentioned example, to control behaviour of helm operations(Install, Upgrade, Delete, etc). Please check CRD spec for all supported helm options and its behaviour.
 
@@ -211,6 +214,7 @@ spec:
   namespace: default
   releaseName: nginx-ingress-1665181073
   repoURL: https://helm.nginx.com/stable
+  version: v2
   values: |
     controller:
       name: "default-23995-nginx"
@@ -218,7 +222,7 @@ spec:
         allowCidrs: 127.0.0.1,::1,192.168.0.0/16
 ```
 
-Notice that a release name is generated for us, and the Go template we specified in `valuesTemplate` has been replaced with the actual values from the Cluster definition.
+Notice that a release name is generated for us, and the Go template we specified in `valuesTemplate` and `versionTemplate` has been replaced with the actual values from the Cluster definition.
 
 ### 6. Uninstall `nginx-ingress` from the workload cluster
 


### PR DESCRIPTION
_This PR introduces a new field called **`VersionTemplate`** in the `HelmChartProxy` CRD._

---

**Background**

Most apps that provide Helm Charts include a _version compatibility matrix_ as part of their versioning policy. For example, see the [Descheduler](https://github.com/kubernetes-sigs/descheduler?tab=readme-ov-file#compatibility-matrix) and [KEDA](https://keda.sh/docs/2.15/operate/cluster/#kubernetes-compatibility) documentation. Given this, it's important to offer a way to override or set the Helm Chart version by comparing values against cluster metadata (such as version, region, data center, etc.). This ensures that the desired Helm Chart version is installed based on specific requirements.

**Motivation**

As early adopters of this Helm provider, we've found that adjusting the Helm Chart version based on metadata can be difficult and often requires workarounds. This negatively impacts the overall developer experience when encountering such cases. Currently, there is no straightforward method for managing chart versions effectively.

**Current Workarounds**

1. **Use `#@` tags**

In your `HelmChartProxy.yaml` file, put the following values on top of the file:

```
#@ load("@ytt:data", "data")
#@ version = data.values.k8s_version
#@ chart_version = ""
#@ if version.startswith("v1.26"):
#@   chart_version = "2.12.1"
#@ elif version.startswith("v1.23"):
#@   chart_version = "2.9.4"
#@ elif version.startswith("v1.20"):
#@   chart_version = "2.8.4"
#@ else:
#@   chart_version = "unsupported"
#@ end
```

Then pass `version: #@ chart_version`

2. **Separate kustomization directories by versions** 

Example:

```
├── metrics-server-k8s-not-v1.16
│   ├── base
│   │   ├── helmchartproxy.yml
│   │   └── kustomization.yml
│   ├── kustomization.yml
│   └── overlays
│       ├── staging
│       │   ├── kustomization.yml
│       │   └── kustomization.yml
│       └── production
│           ├── kustomization.yml
│           └── patch-helmchartproxy.yml
├── metrics-server-k8s-v1.16
│   ├── base
│   │   ...
│   ├── kustomization.yml
│   └── overlays
│       ...
```

And then, you will need to set `clusterSelector.matchExpressions` to add:

```
- key: version
  operator: <OP>
  values:
   - v1.16
```

The `<OP>` should be set to `In` for `metrics-server-k8s-v1.16` and `NotIn` for `metrics-server-k8s-not-v1.16`.

**Current Limitation**

If you manage a flat mono-repo structure for kustomization manifests and need to upgrade a Helm Chart, but some clusters must rely on an older version of the chart, you'll have to completely restructure your folders and kustomization setup to accommodate this. This would create additional complexity and effort in maintaining the repository and HelmChartProxies.

**Proposal**

This PR introduces a new field to `HelmChartProxy` CRD, and its called `VersionTemplate`:

```go
// VersionTemplate is an inline Go template representing the version for the Helm chart. This template supports Go templating
// to reference fields from each selected workload Cluster and programatically create and set the version.
// If the Version is specified, VersionTemplate will take precedence.
// +optional
VersionTemplate string `json:"versionTemplate,omitempty"`
```

It's quite similar to `ValuesTemplate`. By leveraging Go templates, we can gain greater control over the current `version` field. 

* You don't need to deal with `#@` tags
* No need to re-structure of your repository
* No breaking changes
* Pretty basic implementation

**Use Cases*

* Set the Helm Chart version based on specific conditions in your metadata values.
* I have an API that manages the metadata labels for the `Cluster` CR, allowing full automation of which Helm Chart version should be installed on each Kubernetes version. This enables dynamically retrieving the desired version based on the given _labels_ by the API.
* Both `version` and `values` are core Helm flags that are typically set dynamically during the initial installation of an app, so they shouldn't be static fields. To get align with `ValuesTemplate`.

/kind feature

**What this PR does / why we need it**:

See above.

**Which issue(s) this PR fixes**

`-`

/cc @developer-guy
