### PR TITLE
[WIP] 🌱 Fix GitHub linter warnings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,4 @@
+---
 run:
   timeout: 5m
   go: "1.20"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,6 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 # See https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud
+---
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
@@ -8,14 +9,14 @@ steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
     entrypoint: make
     env:
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-    - TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
-    - DOCKER_BUILDKIT=1
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - PULL_BASE_REF=$_PULL_BASE_REF
+      - DOCKER_BUILDKIT=1
     args:
-    - release-staging
+      - release-staging
 substitutions:
-  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
-  # can be used as a substitution
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form
+  # vYYYYMMDD-hash, and can be used as a substitution
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'dev'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,6 +3,7 @@
 # between patch versions.
 #
 # update this file only when a new major or minor version is released
+---
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0

--- a/test/e2e/data/shared/v1beta1-provider/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1-provider/metadata.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:

--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -1,3 +1,4 @@
+---
 name: helm
 config:
   image: gcr.io/k8s-staging-cluster-api-helm/cluster-api-helm-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes small changes to silence the GitHub yaml linter that displays inline warnings on each PR. Example: [Unchanged files with check annotations](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/297/files).

**Which issue(s) this PR fixes**:

N/A
