### PR TITLE
✨ Add `ReconcileStrategy` field to support continuous reconciliation or installing the Helm chart once

### DIFF
--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -22,6 +22,9 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
+// ReconcileStrategy is a string representation of the reconciliation strategy of a HelmChartProxy.
+type ReconcileStrategy string
+
 const (
 	// HelmChartProxyFinalizer is the finalizer used by the HelmChartProxy controller to cleanup add-on resources when
 	// a HelmChartProxy is being deleted.
@@ -29,6 +32,15 @@ const (
 
 	// DefaultOCIKey is the default file name of the OCI secret key.
 	DefaultOCIKey = "config.json"
+
+	// ReconcileStrategyContinuous is the default reconciliation strategy for HelmChartProxy. It will attempt to install the Helm
+	// chart on a selected Cluster, update the Helm release to match the current HelmChartProxy spec, and delete the Helm release
+	// if the Cluster no longer selected.
+	ReconcileStrategyContinuous ReconcileStrategy = "Continuous"
+
+	// ReconcileStrategyInstallOnce attempts to install the Helm chart for a HelmChartProxy on a selected Cluster, and once
+	// it is installed, it will not attempt to update or delete the Helm release on the Cluster again.
+	ReconcileStrategyInstallOnce ReconcileStrategy = "InstallOnce"
 )
 
 // HelmChartProxySpec defines the desired state of HelmChartProxy.
@@ -63,6 +75,14 @@ type HelmChartProxySpec struct {
 	// fields from each selected workload Cluster and programatically create and set values.
 	// +optional
 	ValuesTemplate string `json:"valuesTemplate,omitempty"`
+
+	// ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on selected Clusters,
+	// or if it should be reconciled until it is successfully installed on selected Clusters and not otherwise updated or uninstalled.
+	// If not specified, the default behavior will be to reconcile continuously. This field is immutable.
+	// Possible values are `Continuous`, `InstallOnce`, or unset.
+	// +kubebuilder:validation:Enum="";InstallOnce;Continuous;
+	// +optional
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 
 	// Options represents CLI flags passed to Helm operations (i.e. install, upgrade, delete) and
 	// include options such as wait, skipCRDs, timeout, waitForJobs, etc.

--- a/api/v1alpha1/helmreleaseproxy_types.go
+++ b/api/v1alpha1/helmreleaseproxy_types.go
@@ -32,6 +32,10 @@ const (
 
 	// IsReleaseNameGeneratedAnnotation is the annotation signifying the Helm release name is auto-generated.
 	IsReleaseNameGeneratedAnnotation = "helmreleaseproxy.addons.cluster.x-k8s.io/is-release-name-generated"
+
+	// ReleaseSuccessfullyInstalledAnnotation is the annotation signifying the Helm release has been successfully installed at least once.
+	// This is used to determine if the HelmReleaseProxy is in a ready state for the InstallOnce strategy.
+	ReleaseSuccessfullyInstalledAnnotation = "helmreleaseproxy.addons.cluster.x-k8s.io/release-successfully-installed"
 )
 
 // HelmReleaseProxySpec defines the desired state of HelmReleaseProxy.
@@ -65,6 +69,14 @@ type HelmReleaseProxySpec struct {
 	// Go templating with the values from the referenced workload Cluster.
 	// +optional
 	Values string `json:"values,omitempty"`
+
+	// ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on the Cluster,
+	// or if it should be reconciled until it is successfully installed on the Cluster and not otherwise updated or uninstalled.
+	// If not specified, the default behavior will be to reconcile continuously. This field is immutable.
+	// Possible values are `Continuous`, `InstallOnce`, or unset.
+	// +kubebuilder:validation:Enum="";InstallOnce;Continuous;
+	// +optional
+	ReconcileStrategy string `json:"reconcileStrategy,omitempty"`
 
 	// Options represents the helm setting options which can be used to control behaviour of helm operations(Install, Upgrade, Delete, etc)
 	// via options like wait, skipCrds, timeout, waitForJobs, etc.

--- a/api/v1alpha1/helmreleaseproxy_webhook.go
+++ b/api/v1alpha1/helmreleaseproxy_webhook.go
@@ -59,16 +59,16 @@ func (p *HelmReleaseProxy) Default() {
 var _ webhook.Validator = &HelmReleaseProxy{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (r *HelmReleaseProxy) ValidateCreate() (admission.Warnings, error) {
-	helmreleaseproxylog.Info("validate create", "name", r.Name)
+func (p *HelmReleaseProxy) ValidateCreate() (admission.Warnings, error) {
+	helmreleaseproxylog.Info("validate create", "name", p.Name)
 
 	// TODO(user): fill in your validation logic upon object creation.
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (r *HelmReleaseProxy) ValidateUpdate(oldRaw runtime.Object) (admission.Warnings, error) {
-	helmreleaseproxylog.Info("validate update", "name", r.Name)
+func (p *HelmReleaseProxy) ValidateUpdate(oldRaw runtime.Object) (admission.Warnings, error) {
+	helmreleaseproxylog.Info("validate update", "name", p.Name)
 
 	var allErrs field.ErrorList
 	old, ok := oldRaw.(*HelmReleaseProxy)
@@ -76,31 +76,38 @@ func (r *HelmReleaseProxy) ValidateUpdate(oldRaw runtime.Object) (admission.Warn
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a HelmReleaseProxy but got a %T", old))
 	}
 
-	if !reflect.DeepEqual(r.Spec.RepoURL, old.Spec.RepoURL) {
+	if !reflect.DeepEqual(p.Spec.RepoURL, old.Spec.RepoURL) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "RepoURL"),
-				r.Spec.RepoURL, "field is immutable"),
+				p.Spec.RepoURL, "field is immutable"),
 		)
 	}
 
-	if !reflect.DeepEqual(r.Spec.ChartName, old.Spec.ChartName) {
+	if !reflect.DeepEqual(p.Spec.ChartName, old.Spec.ChartName) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "ChartName"),
-				r.Spec.ChartName, "field is immutable"),
+				p.Spec.ChartName, "field is immutable"),
 		)
 	}
 
-	if !reflect.DeepEqual(r.Spec.ReleaseNamespace, old.Spec.ReleaseNamespace) {
+	if !reflect.DeepEqual(p.Spec.ReleaseNamespace, old.Spec.ReleaseNamespace) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "ReleaseNamespace"),
-				r.Spec.ReleaseNamespace, "field is immutable"),
+				p.Spec.ReleaseNamespace, "field is immutable"),
+		)
+	}
+
+	if p.Spec.ReconcileStrategy != old.Spec.ReconcileStrategy {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "ReconcileStrategy"),
+				p.Spec.ReconcileStrategy, "field is immutable"),
 		)
 	}
 
 	// TODO: add webhook for ReleaseName. Currently it's being set if the release name is generated.
 
 	if len(allErrs) > 0 {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("HelmReleaseProxy").GroupKind(), r.Name, allErrs)
+		return nil, apierrors.NewInvalid(GroupVersion.WithKind("HelmReleaseProxy").GroupKind(), p.Name, allErrs)
 	}
 
 	return nil, nil

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -259,6 +259,17 @@ spec:
                       after a Helm install/upgrade has been performed.
                     type: boolean
                 type: object
+              reconcileStrategy:
+                description: |-
+                  ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on selected Clusters,
+                  or if it should be reconciled until it is successfully installed on selected Clusters and not otherwise updated or uninstalled.
+                  If not specified, the default behavior will be to reconcile continuously. This field is immutable.
+                  Possible values are `Continuous`, `InstallOnce`, or unset.
+                enum:
+                - ""
+                - InstallOnce
+                - Continuous
+                type: string
               releaseName:
                 description: ReleaseName is the release name of the installed Helm
                   chart. If it is not specified, a name will be generated.

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
@@ -266,6 +266,17 @@ spec:
                       after a Helm install/upgrade has been performed.
                     type: boolean
                 type: object
+              reconcileStrategy:
+                description: |-
+                  ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on the Cluster,
+                  or if it should be reconciled until it is successfully installed on the Cluster and not otherwise updated or uninstalled.
+                  If not specified, the default behavior will be to reconcile continuously. This field is immutable.
+                  Possible values are `Continuous`, `InstallOnce`, or unset.
+                enum:
+                - ""
+                - InstallOnce
+                - Continuous
+                type: string
               releaseName:
                 description: ReleaseName is the release name of the installed Helm
                   chart. If it is not specified, a name will be generated.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,7 @@ spec:
           - --leader-elect
           - "--diagnostics-address=${CAAPH_DIAGNOSTICS_ADDRESS:=:8443}"
           - "--insecure-diagnostics=${CAAPH_INSECURE_DIAGNOSTICS:=false}"
+          - "--sync-period=${CAAPH_SYNC_PERIOD:=10m}"
           - "--v=2"
           image: controller:latest
           imagePullPolicy: Always

--- a/controllers/helmchartproxy/helmchartproxy_controller.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller.go
@@ -187,11 +187,14 @@ func (r *HelmChartProxyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *HelmChartProxyReconciler) reconcileNormal(ctx context.Context, helmChartProxy *addonsv1alpha1.HelmChartProxy, clusters []clusterv1.Cluster, helmReleaseProxies []addonsv1alpha1.HelmReleaseProxy) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	log.V(2).Info("Starting reconcileNormal for chart proxy", "name", helmChartProxy.Name)
+	log.V(2).Info("Starting reconcileNormal for chart proxy", "name", helmChartProxy.Name, "strategy", helmChartProxy.Spec.ReconcileStrategy)
 
-	err := r.deleteOrphanedHelmReleaseProxies(ctx, helmChartProxy, clusters, helmReleaseProxies)
-	if err != nil {
-		return err
+	// If Reconcile strategy is not InstallOnce, delete orphaned HelmReleaseProxies
+	if !(helmChartProxy.Spec.ReconcileStrategy == string(addonsv1alpha1.ReconcileStrategyInstallOnce)) {
+		err := r.deleteOrphanedHelmReleaseProxies(ctx, helmChartProxy, clusters, helmReleaseProxies)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, cluster := range clusters {

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
@@ -47,12 +47,13 @@ var (
 			Namespace: "test-namespace",
 		},
 		Spec: addonsv1alpha1.HelmChartProxySpec{
-			ReleaseName:      "test-release-name",
-			ChartName:        "test-chart-name",
-			RepoURL:          "https://test-repo-url",
-			ReleaseNamespace: "test-release-namespace",
-			Version:          "test-version",
-			ValuesTemplate:   "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			Options: addonsv1alpha1.HelmOptions{
 				EnableClientCache: true,
 				Timeout: &metav1.Duration{
@@ -72,12 +73,64 @@ var (
 			Namespace: "test-namespace",
 		},
 		Spec: addonsv1alpha1.HelmChartProxySpec{
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "cidrBlockList: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join \",\" }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+
+	fakeNoStrategyHelmChartProxy1 = &addonsv1alpha1.HelmChartProxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: addonsv1alpha1.GroupVersion.String(),
+			Kind:       "HelmChartProxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-namespace",
+		},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
 			ReleaseName:      "test-release-name",
 			ChartName:        "test-chart-name",
 			RepoURL:          "https://test-repo-url",
 			ReleaseNamespace: "test-release-namespace",
 			Version:          "test-version",
-			ValuesTemplate:   "cidrBlockList: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join \",\" }}",
+			ValuesTemplate:   "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+
+	fakeNoStrategyHelmChartProxy2 = &addonsv1alpha1.HelmChartProxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: addonsv1alpha1.GroupVersion.String(),
+			Kind:       "HelmChartProxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-namespace",
+		},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "cidrBlockList: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join \",\" }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			Options: addonsv1alpha1.HelmOptions{
 				EnableClientCache: true,
 				Timeout: &metav1.Duration{
@@ -97,12 +150,13 @@ var (
 			Namespace: "test-namespace",
 		},
 		Spec: addonsv1alpha1.HelmChartProxySpec{
-			ReleaseName:      "test-release-name",
-			ChartName:        "test-chart-name",
-			RepoURL:          "https://test-repo-url",
-			ReleaseNamespace: "test-release-namespace",
-			Version:          "test-version",
-			ValuesTemplate:   "apiServerPort: {{ .Cluster.invalid-path }}",
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "apiServerPort: {{ .Cluster.invalid-path }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			Options: addonsv1alpha1.HelmOptions{
 				EnableClientCache: true,
 				Timeout: &metav1.Duration{
@@ -122,12 +176,91 @@ var (
 			Namespace: "test-namespace",
 		},
 		Spec: addonsv1alpha1.HelmChartProxySpec{
-			ReleaseName:      "other-release-name",
-			ChartName:        "other-chart-name",
-			RepoURL:          "https://other-repo-url",
-			ReleaseNamespace: "test-release-namespace",
-			Version:          "test-version",
-			ValuesTemplate:   "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReleaseName:       "other-release-name",
+			ChartName:         "other-chart-name",
+			RepoURL:           "https://other-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+
+	fakeNoStrategyReinstallHelmChartProxy = &addonsv1alpha1.HelmChartProxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: addonsv1alpha1.GroupVersion.String(),
+			Kind:       "HelmChartProxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-namespace",
+		},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			ReleaseName:       "other-release-name",
+			ChartName:         "other-chart-name",
+			RepoURL:           "https://other-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+
+	fakeInstallOnceHelmChartProxy1 = &addonsv1alpha1.HelmChartProxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: addonsv1alpha1.GroupVersion.String(),
+			Kind:       "HelmChartProxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-namespace",
+		},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyInstallOnce),
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
+
+	fakeInstallOnceHelmChartProxy2 = &addonsv1alpha1.HelmChartProxy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: addonsv1alpha1.GroupVersion.String(),
+			Kind:       "HelmChartProxy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-namespace",
+		},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			ReleaseName:       "test-release-name",
+			ChartName:         "test-chart-name",
+			RepoURL:           "https://test-repo-url",
+			ReleaseNamespace:  "test-release-namespace",
+			Version:           "test-version",
+			ValuesTemplate:    "cidrBlockList: {{ .Cluster.spec.clusterNetwork.pods.cidrBlocks | join \",\" }}",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyInstallOnce),
 			Options: addonsv1alpha1.HelmOptions{
 				EnableClientCache: true,
 				Timeout: &metav1.Duration{
@@ -234,6 +367,49 @@ var (
 			},
 		},
 	}
+
+	fakeReadyHelmReleaseProxy = &addonsv1alpha1.HelmReleaseProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-generated-name",
+			Namespace: "test-namespace",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         addonsv1alpha1.GroupVersion.String(),
+					Kind:               "HelmChartProxy",
+					Name:               "test-hcp",
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:             "test-cluster",
+				addonsv1alpha1.HelmChartProxyLabelName: "test-hcp",
+			},
+			Annotations: map[string]string{
+				addonsv1alpha1.ReleaseSuccessfullyInstalledAnnotation: "true",
+			},
+		},
+		Spec: addonsv1alpha1.HelmReleaseProxySpec{
+			ClusterRef: corev1.ObjectReference{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Cluster",
+				Name:       "test-cluster",
+				Namespace:  "test-namespace",
+			},
+			ReleaseName:      "test-release-name",
+			ChartName:        "test-chart-name",
+			RepoURL:          "https://test-repo-url",
+			ReleaseNamespace: "test-release-namespace",
+			Version:          "test-version",
+			Values:           "apiServerPort: 6443",
+			Options: addonsv1alpha1.HelmOptions{
+				EnableClientCache: true,
+				Timeout: &metav1.Duration{
+					Duration: 10 * time.Minute,
+				},
+			},
+		},
+	}
 )
 
 func TestReconcileForCluster(t *testing.T) {
@@ -308,6 +484,98 @@ func TestReconcileForCluster(t *testing.T) {
 				g.Expect(specsReady.Reason).To(Equal(addonsv1alpha1.HelmReleaseProxyReinstallingReason))
 				g.Expect(specsReady.Severity).To(Equal(clusterv1.ConditionSeverityInfo))
 				g.Expect(specsReady.Message).To(Equal(fmt.Sprintf("HelmReleaseProxy on cluster '%s' successfully deleted, preparing to reinstall", fakeCluster1.Name)))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "creates a HelmReleaseProxy for a HelmChartProxy when strategy is unset",
+			helmChartProxy:                fakeNoStrategyHelmChartProxy1,
+			cluster:                       fakeCluster1,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("apiServerPort: 6443"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "updates a HelmReleaseProxy when Cluster value changes when strategy is unset",
+			helmChartProxy:                fakeNoStrategyHelmChartProxy1,
+			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("apiServerPort: 1234"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "updates a HelmReleaseProxy when valuesTemplate value changes when strategy is unset",
+			helmChartProxy:                fakeNoStrategyHelmChartProxy2,
+			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("cidrBlockList: 10.0.0.0/16,20.0.0.0/16"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "set condition for reinstalling when requeueing after a deletion when strategy is unset",
+			helmChartProxy:                fakeNoStrategyReinstallHelmChartProxy,
+			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
+			cluster:                       fakeCluster1,
+			expectHelmReleaseProxyToExist: false,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(conditions.Has(hcp, addonsv1alpha1.HelmReleaseProxySpecsUpToDateCondition)).To(BeTrue())
+				specsReady := conditions.Get(hcp, addonsv1alpha1.HelmReleaseProxySpecsUpToDateCondition)
+				g.Expect(specsReady.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(specsReady.Reason).To(Equal(addonsv1alpha1.HelmReleaseProxyReinstallingReason))
+				g.Expect(specsReady.Severity).To(Equal(clusterv1.ConditionSeverityInfo))
+				g.Expect(specsReady.Message).To(Equal(fmt.Sprintf("HelmReleaseProxy on cluster '%s' successfully deleted, preparing to reinstall", fakeCluster1.Name)))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "when strategy is InstallOnce, do not update if HelmReleaseProxy is ready when Cluster value changes",
+			helmChartProxy:                fakeInstallOnceHelmChartProxy1,
+			existingHelmReleaseProxy:      fakeReadyHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("apiServerPort: 6443"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "when strategy is InstallOnce, do not update if HelmReleaseProxy is ready when valuesTemplate value changes",
+			helmChartProxy:                fakeInstallOnceHelmChartProxy2,
+			existingHelmReleaseProxy:      fakeReadyHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("apiServerPort: 6443"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "when strategy is InstallOnce, update if HelmReleaseProxy is not ready when Cluster value changes",
+			helmChartProxy:                fakeInstallOnceHelmChartProxy1,
+			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("apiServerPort: 1234"))
+			},
+			expectedError: "",
+		},
+		{
+			name:                          "when strategy is InstallOnce, update if HelmReleaseProxy is not ready when valuesTemplate value changes",
+			helmChartProxy:                fakeInstallOnceHelmChartProxy2,
+			existingHelmReleaseProxy:      fakeHelmReleaseProxy,
+			cluster:                       fakeCluster2,
+			expectHelmReleaseProxyToExist: true,
+			expect: func(g *WithT, hcp *addonsv1alpha1.HelmChartProxy, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				g.Expect(hrp.Spec.Values).To(Equal("cidrBlockList: 10.0.0.0/16,20.0.0.0/16"))
 			},
 			expectedError: "",
 		},

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
@@ -59,13 +59,89 @@ var (
 				Namespace:  "default",
 				Name:       "test-cluster",
 			},
-			RepoURL:          "https://test-repo",
-			ChartName:        "test-chart",
-			Version:          "test-version",
-			ReleaseName:      "test-release",
-			ReleaseNamespace: "default",
-			Values:           "test-values",
-			Credentials:      nil,
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
+			Credentials:       nil,
+		},
+	}
+
+	installOnceProxyAlreadyInstalled = &addonsv1alpha1.HelmReleaseProxy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmReleaseProxy",
+			APIVersion: "addons.cluster.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-proxy",
+			Namespace: "default",
+			Annotations: map[string]string{
+				addonsv1alpha1.ReleaseSuccessfullyInstalledAnnotation: "true",
+			},
+		},
+		Spec: addonsv1alpha1.HelmReleaseProxySpec{
+			ClusterRef: corev1.ObjectReference{
+				APIVersion: "cluster.x-k8s.io/v1beta1",
+				Kind:       "Cluster",
+				Namespace:  "default",
+				Name:       "test-cluster",
+			},
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyInstallOnce),
+			Credentials:       nil,
+		},
+		Status: addonsv1alpha1.HelmReleaseProxyStatus{
+			Status:   string(helmRelease.StatusDeployed),
+			Revision: 1,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   addonsv1alpha1.HelmReleaseReadyCondition,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   addonsv1alpha1.ClusterAvailableCondition,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   clusterv1.ReadyCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	installOnceProxyNotInstalled = &addonsv1alpha1.HelmReleaseProxy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmReleaseProxy",
+			APIVersion: "addons.cluster.x-k8s.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-proxy",
+			Namespace: "default",
+		},
+		Spec: addonsv1alpha1.HelmReleaseProxySpec{
+			ClusterRef: corev1.ObjectReference{
+				APIVersion: "cluster.x-k8s.io/v1beta1",
+				Kind:       "Cluster",
+				Namespace:  "default",
+				Name:       "test-cluster",
+			},
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyInstallOnce),
+			Credentials:       nil,
 		},
 	}
 
@@ -85,12 +161,13 @@ var (
 				Namespace:  "default",
 				Name:       "test-cluster",
 			},
-			RepoURL:          "https://test-repo",
-			ChartName:        "test-chart",
-			Version:          "test-version",
-			ReleaseName:      "test-release",
-			ReleaseNamespace: "default",
-			Values:           "test-values",
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			Credentials: &addonsv1alpha1.Credentials{
 				Secret: corev1.SecretReference{
 					Name:      "test-secret",
@@ -116,12 +193,13 @@ var (
 				Namespace:  "default",
 				Name:       "test-cluster",
 			},
-			RepoURL:          "https://test-repo",
-			ChartName:        "test-chart",
-			Version:          "test-version",
-			ReleaseName:      "test-release",
-			ReleaseNamespace: "default",
-			Values:           "test-values",
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			TLSConfig: &addonsv1alpha1.TLSConfig{
 				CASecretRef: &corev1.SecretReference{
 					Name:      "test-secret",
@@ -147,12 +225,13 @@ var (
 				Namespace:  "default",
 				Name:       "test-cluster",
 			},
-			RepoURL:          "https://test-repo",
-			ChartName:        "test-chart",
-			Version:          "test-version",
-			ReleaseName:      "test-release",
-			ReleaseNamespace: "default",
-			Values:           "test-values",
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseName:       "test-release",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 			TLSConfig: &addonsv1alpha1.TLSConfig{
 				InsecureSkipTLSVerify: true,
 			},
@@ -175,11 +254,12 @@ var (
 				Namespace:  "default",
 				Name:       "test-cluster",
 			},
-			RepoURL:          "https://test-repo",
-			ChartName:        "test-chart",
-			Version:          "test-version",
-			ReleaseNamespace: "default",
-			Values:           "test-values",
+			RepoURL:           "https://test-repo",
+			ChartName:         "test-chart",
+			Version:           "test-version",
+			ReleaseNamespace:  "default",
+			Values:            "test-values",
+			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
 		},
 	}
 
@@ -310,6 +390,52 @@ func TestReconcileNormal(t *testing.T) {
 				g.Expect(releaseReady.Reason).To(Equal(addonsv1alpha1.HelmInstallOrUpgradeFailedReason))
 				g.Expect(releaseReady.Severity).To(Equal(clusterv1.ConditionSeverityError))
 				g.Expect(releaseReady.Message).To(Equal(fmt.Sprintf("Helm release failed: %s", helmRelease.StatusFailed)))
+			},
+			expectedError: "",
+		},
+		{
+			name:             "do nothing if already successfully and installed strategy is InstallOnce",
+			helmReleaseProxy: installOnceProxyAlreadyInstalled.DeepCopy(),
+			clientExpect: func(g *WithT, c *mocks.MockClientMockRecorder) {
+				// no client calls expected
+			},
+			expect: func(g *WithT, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				_, ok := hrp.Annotations[addonsv1alpha1.IsReleaseNameGeneratedAnnotation]
+				g.Expect(ok).To(BeFalse())
+				g.Expect(hrp.Spec.ReleaseName).To(Equal("test-release"))
+				g.Expect(hrp.Status.Revision).To(Equal(1))
+				g.Expect(hrp.Status.Status).To(BeEquivalentTo(helmRelease.StatusDeployed))
+
+				g.Expect(conditions.Has(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
+				g.Expect(conditions.IsTrue(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
+			},
+			expectedError: "",
+		},
+		{
+			name:             "successfully install a Helm release when strategy is InstallOnce",
+			helmReleaseProxy: installOnceProxyNotInstalled.DeepCopy(),
+			clientExpect: func(g *WithT, c *mocks.MockClientMockRecorder) {
+				c.InstallOrUpgradeHelmRelease(ctx, restConfig, "", "", installOnceProxyNotInstalled.DeepCopy().Spec).Return(&helmRelease.Release{
+					Name:    "test-release",
+					Version: 1,
+					Info: &helmRelease.Info{
+						Status: helmRelease.StatusDeployed,
+					},
+				}, nil).Times(1)
+			},
+			expect: func(g *WithT, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				_, ok := hrp.Annotations[addonsv1alpha1.IsReleaseNameGeneratedAnnotation]
+				g.Expect(ok).To(BeFalse())
+
+				_, ok = hrp.Annotations[addonsv1alpha1.ReleaseSuccessfullyInstalledAnnotation]
+				g.Expect(ok).To(BeTrue())
+
+				g.Expect(hrp.Spec.ReleaseName).To(Equal("test-release"))
+				g.Expect(hrp.Status.Revision).To(Equal(1))
+				g.Expect(hrp.Status.Status).To(BeEquivalentTo(helmRelease.StatusDeployed))
+
+				g.Expect(conditions.Has(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
+				g.Expect(conditions.IsTrue(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
 			},
 			expectedError: "",
 		},
@@ -538,6 +664,19 @@ func TestReconcileDelete(t *testing.T) {
 				g.Expect(releaseReady.Severity).To(Equal(clusterv1.ConditionSeverityError))
 			},
 			expectedError: errInternal.Error(),
+		},
+		{
+			name:             "do nothing when strategy is InstallOnce",
+			helmReleaseProxy: installOnceProxyAlreadyInstalled.DeepCopy(),
+			clientExpect: func(g *WithT, c *mocks.MockClientMockRecorder) {
+				// no client calls expected
+			},
+			expect: func(g *WithT, hrp *addonsv1alpha1.HelmReleaseProxy) {
+				// Since the condition was set to true before, it should remain true.
+				g.Expect(conditions.Has(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
+				g.Expect(conditions.IsTrue(hrp, addonsv1alpha1.HelmReleaseReadyCondition)).To(BeTrue())
+			},
+			expectedError: "",
 		},
 	}
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+)
+
+// HasHelmReleaseBeenSuccessfullyInstalled returns true if the Helm chart has been successfully installed at least once
+// for a HelmReleaseProxy.
+func HasHelmReleaseBeenSuccessfullyInstalled(hrp *addonsv1alpha1.HelmReleaseProxy) bool {
+	if hrp == nil {
+		return false
+	}
+
+	if annotations := hrp.GetAnnotations(); annotations != nil {
+		_, ok := annotations[addonsv1alpha1.ReleaseSuccessfullyInstalledAnnotation]
+		return ok
+	}
+
+	return false
+}

--- a/test/e2e/config/helm.yaml
+++ b/test/e2e/config/helm.yaml
@@ -139,6 +139,7 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
+  CAAPH_SYNC_PERIOD: "1m" # To ensure that we can reconcile several times during the InstallOnce tests.
   KUBERNETES_VERSION_MANAGEMENT: "v1.29.0"
   KUBERNETES_VERSION: "v1.29.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.28.0"

--- a/test/e2e/helm_out_of_band.go
+++ b/test/e2e/helm_out_of_band.go
@@ -1,0 +1,103 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+// HelmReleaseOutOfBandInput specifies the input for updating an existing Helm release out-of-band and verifying that the changes do not get reverted
+// on the InstallOnce strategy.
+type HelmReleaseOutOfBandInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	HelmChartProxy        *addonsv1alpha1.HelmChartProxy // Note: Only the Spec field is used.
+	Values                []string                       // The values to apply to the Helm release out-of-band.
+	WaitPeriod            time.Duration                  // The time to wait before verifying that the Helm release is unchanged.
+}
+
+// HelmReleaseOutOfBandSpec implements a test that verifies an existing Helm release will not be changed on the InstallOnce strategy when the HelmChartProxy
+// changes or the cluster is unselected. It assumes that the Helm release was installed successfully prior and verifies that the Helm release is unchanged.
+func HelmReleaseOutOfBandSpec(ctx context.Context, inputGetter func() HelmReleaseOutOfBandInput) {
+	var (
+		specName   = "helm-upgrade"
+		input      HelmReleaseOutOfBandInput
+		mgmtClient ctrlclient.Client
+		err        error
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the management cluster")
+	mgmtClient = input.BootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	// Get existing HCP from management Cluster
+	existing := &addonsv1alpha1.HelmChartProxy{}
+	key := types.NamespacedName{
+		Namespace: input.HelmChartProxy.Namespace,
+		Name:      input.HelmChartProxy.Name,
+	}
+	err = mgmtClient.Get(ctx, key, existing)
+	Expect(err).NotTo(HaveOccurred())
+
+	// We want to get the Helm release using WaitForHelmReleaseProxyReady and WaitForHelmReleaseDeployed
+	// First, wait for initial HelmReleaseProxy to be ready
+	hrpWaitInput := GetWaitForHelmReleaseProxyReadyInput(ctx, bootstrapClusterProxy, input.ClusterName, *input.HelmChartProxy, 1, specName)
+	WaitForHelmReleaseProxyReady(ctx, hrpWaitInput, e2eConfig.GetIntervals(specName, "wait-helmreleaseproxy-ready")...)
+
+	// Then, get workload Cluster proxy
+	By("creating a clusterctl proxy to the workload cluster")
+	workloadClusterProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(workloadClusterProxy).NotTo(BeNil())
+
+	// Finally, wait for Helm release on workload cluster to have status = deployed
+	existingReleaseWaitInput := GetWaitForHelmReleaseDeployedInput(ctx, workloadClusterProxy, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseName, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseNamespace, specName)
+	existingRelease := WaitForHelmReleaseDeployed(ctx, existingReleaseWaitInput, e2eConfig.GetIntervals(specName, "wait-helm-existingRelease-deployed")...)
+
+	// Invoke UpgradeHelmChart logic here
+	options := &HelmOptions{
+		Values: input.Values,
+	}
+	UpgradeHelmChart(ctx, workloadClusterProxy, existingRelease.Namespace, input.HelmChartProxy.Spec.RepoURL, existingRelease.Chart.Name(), existingRelease.Name, options, existingRelease.Chart.Metadata.Version)
+	// Is there a better way to ensure that the release won't change, besides waiting for a period of time and checking back?
+
+	// Wait for Helm release on workload cluster to have status = deployed
+	releaseWaitInput := GetWaitForHelmReleaseDeployedInput(ctx, workloadClusterProxy, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseName, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseNamespace, specName)
+	release := WaitForHelmReleaseDeployed(ctx, releaseWaitInput, e2eConfig.GetIntervals(specName, "wait-helm-release-deployed")...)
+
+	Byf("waiting for %v to ensure the Helm release does not change", input.WaitPeriod.Minutes())
+	time.Sleep(input.WaitPeriod)
+
+	EnsureHelmReleaseUnchanged(ctx, specName, input.BootstrapClusterProxy, input.ClusterName, input.Namespace.Name, release)
+}

--- a/test/e2e/helm_unchanged.go
+++ b/test/e2e/helm_unchanged.go
@@ -1,0 +1,99 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+// HelmReleaseUnchangedInput specifies the input for updating or reinstalling a Helm chart on a workload cluster and verifying that it was successful.
+type HelmReleaseUnchangedInput struct {
+	BootstrapClusterProxy framework.ClusterProxy
+	Namespace             *corev1.Namespace
+	ClusterName           string
+	HelmChartProxy        *addonsv1alpha1.HelmChartProxy // Note: Only the Spec field is used.
+}
+
+// HelmReleaseUnchangedSpec implements a test that verifies an existing Helm release will not be changed on the InstallOnce strategy when the HelmChartProxy
+// changes or the cluster is unselected. It assumes that the Helm release was installed successfully prior and verifies that the Helm release is unchanged.
+func HelmReleaseUnchangedSpec(ctx context.Context, inputGetter func() HelmReleaseUnchangedInput) {
+	var (
+		specName   = "helm-upgrade"
+		input      HelmReleaseUnchangedInput
+		mgmtClient ctrlclient.Client
+		err        error
+	)
+
+	input = inputGetter()
+	Expect(input.BootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+	Expect(input.Namespace).NotTo(BeNil(), "Invalid argument. input.Namespace can't be nil when calling %s spec", specName)
+
+	By("creating a Kubernetes client to the management cluster")
+	mgmtClient = input.BootstrapClusterProxy.GetClient()
+	Expect(mgmtClient).NotTo(BeNil())
+
+	// Get existing HCP from management Cluster
+	existing := &addonsv1alpha1.HelmChartProxy{}
+	key := types.NamespacedName{
+		Namespace: input.HelmChartProxy.Namespace,
+		Name:      input.HelmChartProxy.Name,
+	}
+	err = mgmtClient.Get(ctx, key, existing)
+	Expect(err).NotTo(HaveOccurred())
+
+	// We want to get the Helm release using WaitForHelmReleaseProxyReady and WaitForHelmReleaseDeployed
+	// First, wait for initial HelmReleaseProxy to be ready
+	hrpWaitInput := GetWaitForHelmReleaseProxyReadyInput(ctx, bootstrapClusterProxy, input.ClusterName, *input.HelmChartProxy, 1, specName)
+	WaitForHelmReleaseProxyReady(ctx, hrpWaitInput, e2eConfig.GetIntervals(specName, "wait-helmreleaseproxy-ready")...)
+
+	// Then, get workload Cluster proxy
+	By("creating a clusterctl proxy to the workload cluster")
+	workloadClusterProxy := bootstrapClusterProxy.GetWorkloadCluster(ctx, input.Namespace.Name, input.ClusterName)
+	Expect(workloadClusterProxy).NotTo(BeNil())
+
+	// Finally, wait for Helm release on workload cluster to have status = deployed
+	releaseWaitInput := GetWaitForHelmReleaseDeployedInput(ctx, workloadClusterProxy, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseName, hrpWaitInput.HelmReleaseProxy.Spec.ReleaseNamespace, specName)
+	release := WaitForHelmReleaseDeployed(ctx, releaseWaitInput, e2eConfig.GetIntervals(specName, "wait-helm-release-deployed")...)
+
+	// Patch HCP on management Cluster
+	Byf("Patching HelmChartProxy %s/%s", existing.Namespace, existing.Name)
+	patchHelper, err := patch.NewHelper(existing, mgmtClient)
+	Expect(err).ToNot(HaveOccurred())
+
+	existing.Spec = input.HelmChartProxy.Spec
+	input.HelmChartProxy = existing
+
+	Eventually(func() error {
+		return patchHelper.Patch(ctx, existing)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to patch HelmChartProxy %s", klog.KObj(existing))
+
+	EnsureHelmReleaseUnchanged(ctx, specName, input.BootstrapClusterProxy, input.ClusterName, input.Namespace.Name, release)
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Introduces a field called `ReconcileStrategy` which allows the user to specify if reconciliation will be continuous (as usual) or if the Helm chart should be successfully installed and no longer reconciled. This is intended as a "fire-and-forget" mode where users intend to hand off their Helm chart to GitOps or to make out of band changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #65
