### PR TITLE
:sparkles: Able to run controller inside the container platform with write access to root restrictions

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,16 +30,28 @@ spec:
           type: RuntimeDefault
       containers:
         - args:
-          - --leader-elect
-          - "--diagnostics-address=${CAAPH_DIAGNOSTICS_ADDRESS:=:8443}"
-          - "--insecure-diagnostics=${CAAPH_INSECURE_DIAGNOSTICS:=false}"
-          - "--sync-period=${CAAPH_SYNC_PERIOD:=10m}"
-          - "--v=2"
+            - --leader-elect
+            - "--diagnostics-address=${CAAPH_DIAGNOSTICS_ADDRESS:=:8443}"
+            - "--insecure-diagnostics=${CAAPH_INSECURE_DIAGNOSTICS:=false}"
+            - "--sync-period=${CAAPH_SYNC_PERIOD:=10m}"
+            - "--v=2"
+          env:
+            - name: XDG_DATA_HOME
+              value: /tmp/xdg/.data
+            - name: XDG_CONFIG_HOME
+              value: /tmp/xdg/.config
+            - name: XDG_STATE_HOME
+              value: /tmp/xdg/.state
+            - name: XDG_CACHE_HOME
+              value: /tmp/xdg/.cache
+            - name: XDG_CONFIG_DIRS
+              value: /tmp/xdg
           image: controller:latest
           imagePullPolicy: Always
           name: manager
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -65,6 +77,12 @@ spec:
               port: healthz
             initialDelaySeconds: 10
             periodSeconds: 10
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - emptyDir: {}
+          name: tmp
           # TODO(user): Configure the resources accordingly based on the project requirements.
           # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
           # resources:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This fix allows you to run a container with an operator on platforms that do not allow writing data to the root directory, such as OpenShift. 

The approach used is very simple, we mount /xdg as an emptyDir volume and redirect XDG_* variables used by helm there. This should work for upstream Kubernetes as well, but e2e validation is required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #236 
