### PR TITLE
✨ Add HelmChartProxy spec field for mapping Kubernetes versions to Helm chart versions

### DIFF
--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -71,6 +71,16 @@ type HelmChartProxySpec struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 
+	// VersionMap is a map of Kubernetes versions to Helm chart versions. This is used to represent a compatibility matrix
+	// between Kubernetes versions and Helm chart versions. Both the Kubernetes versions and Helm chart versions can be specified
+	// not only as exact versions (i.e. v1.3, v1.3.2) but also as any valid semver range (i.e. >1.3, 1.3.x, 1.3 - 1.4, ^1.2.3, ~1.2.3).
+	//
+	// Note: version ranges specified using a hyphen (i.e. 1.3 - 1.4) must include a space on either side of the hyphen, 1.3-1.4 will
+	// be parsed as release 1.3 with pre-release 1.4.
+	// Note: exact versions with patch versions must be specified for OCI charts.
+	VersionMap map[string]string `json:"versionMap,omitempty"`
+	// TODO: verify how versions work for OCI charts
+
 	// ValuesTemplate is an inline YAML representing the values for the Helm chart. This YAML supports Go templating to reference
 	// fields from each selected workload Cluster and programatically create and set values.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -106,6 +106,13 @@ func (in *HelmChartProxyList) DeepCopyObject() runtime.Object {
 func (in *HelmChartProxySpec) DeepCopyInto(out *HelmChartProxySpec) {
 	*out = *in
 	in.ClusterSelector.DeepCopyInto(&out.ClusterSelector)
+	if in.VersionMap != nil {
+		in, out := &in.VersionMap, &out.VersionMap
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Options.DeepCopyInto(&out.Options)
 	if in.Credentials != nil {
 		in, out := &in.Credentials, &out.Credentials

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -311,6 +311,18 @@ spec:
                   Version is the version of the Helm chart. If it is not specified, the chart will use
                   and be kept up to date with the latest version.
                 type: string
+              versionMap:
+                additionalProperties:
+                  type: string
+                description: |-
+                  VersionMap is a map of Kubernetes versions to Helm chart versions. This is used to represent a compatibility matrix
+                  between Kubernetes versions and Helm chart versions. Both the Kubernetes versions and Helm chart versions can be specified
+                  not only as exact versions (i.e. v1.3, v1.3.2) but also as any valid semver range (i.e. >1.3, 1.3.x, 1.3 - 1.4, ^1.2.3, ~1.2.3).
+
+                  Note: version ranges specified using a hyphen (i.e. 1.3 - 1.4) must include a space on either side of the hyphen, 1.3-1.4 will
+                  be parsed as release 1.3 with pre-release 1.4.
+                  Note: exact versions with patch versions must be specified for OCI charts.
+                type: object
             required:
             - chartName
             - clusterSelector

--- a/config/samples/calico-cni.yaml
+++ b/config/samples/calico-cni.yaml
@@ -27,4 +27,3 @@ spec:
           encapsulation: None
           natOutgoing: Enabled
           nodeSelector: all(){{end}}
-  # TODO: pay attention to newlines at the end that get inserted by templates

--- a/config/samples/descheduler.yaml
+++ b/config/samples/descheduler.yaml
@@ -1,0 +1,35 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: descheduler
+spec:
+  clusterSelector:
+  # Target workload clusters with specific labels.
+  #  matchLabels:
+  #    calicoCNI: enabled
+  # Target all workload clusters.
+    matchLabels: {}
+  releaseName: descheduler
+  repoURL: https://kubernetes-sigs.github.io/descheduler/
+  chartName: descheduler
+  versionMap: 
+    "1.32": "0.32"
+    "1.31": "0.31"
+    "1.30": "0.30"
+    "1.29": "0.29"
+    "1.28": "0.28"
+    "1.27": "0.27"
+    "1.26": "0.26"
+    "1.25": "0.25"
+    "1.24": "0.24"
+    "1.23": "0.23"
+    "1.22": "0.22"
+    "1.21": "0.21"
+    "1.20": "0.20"
+    "1.19": "0.19"
+    "1.18": "0.18"
+    "1.17": "0.10"
+    "1.9 - 1.16": "0.4 - 0.9"
+    "1.7 - 1.8": "0.3.0"
+  valuesTemplate: |
+    kind: CronJob

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -127,7 +127,7 @@ func (r *HelmChartProxyReconciler) getHelmChartVersionForCluster(ctx context.Con
 		return helmChartProxy.Spec.Version, nil
 	}
 
-	if cluster.Spec.ControlPlaneRef != nil {
+	if cluster.Spec.ControlPlaneRef == nil {
 		return "", errors.New("control plane reference is not set")
 	}
 
@@ -187,10 +187,8 @@ func (r *HelmChartProxyReconciler) createOrUpdateHelmReleaseProxy(ctx context.Co
 
 	version, err := r.getHelmChartVersionForCluster(ctx, helmChartProxy, cluster)
 	if err != nil {
-		// TODO: Should we set a condition here?
 		return errors.Wrapf(err, "failed to resolve Kubernetes version for cluster %s", cluster.Name)
 	}
-	// TODO: do something with the computed version
 
 	helmReleaseProxy := constructHelmReleaseProxy(existing, helmChartProxy, parsedValues, cluster, version)
 	if helmReleaseProxy == nil {

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -25,9 +25,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-addon-provider-helm/internal"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -118,6 +120,33 @@ func (r *HelmChartProxyReconciler) reconcileForCluster(ctx context.Context, helm
 	return nil
 }
 
+func (r *HelmChartProxyReconciler) getHelmChartVersionForCluster(ctx context.Context, helmChartProxy *addonsv1alpha1.HelmChartProxy, cluster *clusterv1.Cluster) (string, error) {
+	_ = ctrl.LoggerFrom(ctx)
+
+	if helmChartProxy.Spec.VersionMap == nil {
+		return helmChartProxy.Spec.Version, nil
+	}
+
+	if cluster.Spec.ControlPlaneRef != nil {
+		return "", errors.New("control plane reference is not set")
+	}
+
+	controlPlane, err := external.Get(ctx, r.Client, cluster.Spec.ControlPlaneRef)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get control plane object %s", cluster.Spec.ControlPlaneRef.Name)
+	}
+
+	v, found, err := unstructured.NestedString(controlPlane.Object, "spec", "version")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get control plane version from object %s", cluster.Spec.ControlPlaneRef.Name)
+	}
+	if !found {
+		return "", errors.New("control plane version not found")
+	}
+
+	return internal.ResolveHelmChartVersion(v, helmChartProxy.Spec.VersionMap)
+}
+
 // getExistingHelmReleaseProxy returns the HelmReleaseProxy for the given cluster if it exists.
 func (r *HelmChartProxyReconciler) getExistingHelmReleaseProxy(ctx context.Context, helmChartProxy *addonsv1alpha1.HelmChartProxy, cluster *clusterv1.Cluster) (*addonsv1alpha1.HelmReleaseProxy, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -155,7 +184,15 @@ func (r *HelmChartProxyReconciler) getExistingHelmReleaseProxy(ctx context.Conte
 // createOrUpdateHelmReleaseProxy creates or updates the HelmReleaseProxy for the given cluster.
 func (r *HelmChartProxyReconciler) createOrUpdateHelmReleaseProxy(ctx context.Context, existing *addonsv1alpha1.HelmReleaseProxy, helmChartProxy *addonsv1alpha1.HelmChartProxy, cluster *clusterv1.Cluster, parsedValues string) error {
 	log := ctrl.LoggerFrom(ctx)
-	helmReleaseProxy := constructHelmReleaseProxy(existing, helmChartProxy, parsedValues, cluster)
+
+	version, err := r.getHelmChartVersionForCluster(ctx, helmChartProxy, cluster)
+	if err != nil {
+		// TODO: Should we set a condition here?
+		return errors.Wrapf(err, "failed to resolve Kubernetes version for cluster %s", cluster.Name)
+	}
+	// TODO: do something with the computed version
+
+	helmReleaseProxy := constructHelmReleaseProxy(existing, helmChartProxy, parsedValues, cluster, version)
 	if helmReleaseProxy == nil {
 		log.V(2).Info("HelmReleaseProxy is up to date, nothing to do", "helmReleaseProxy", existing.Name, "cluster", cluster.Name)
 		return nil
@@ -192,7 +229,7 @@ func (r *HelmChartProxyReconciler) deleteHelmReleaseProxy(ctx context.Context, h
 
 // constructHelmReleaseProxy constructs a new HelmReleaseProxy for the given Cluster or updates the existing HelmReleaseProxy if needed.
 // If no update is needed, this returns nil. Note that this does not check if we need to reinstall the HelmReleaseProxy, i.e. immutable fields changed.
-func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmChartProxy *addonsv1alpha1.HelmChartProxy, parsedValues string, cluster *clusterv1.Cluster) *addonsv1alpha1.HelmReleaseProxy {
+func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmChartProxy *addonsv1alpha1.HelmChartProxy, parsedValues string, cluster *clusterv1.Cluster, version string) *addonsv1alpha1.HelmReleaseProxy {
 	helmReleaseProxy := &addonsv1alpha1.HelmReleaseProxy{}
 	if existing == nil {
 		helmReleaseProxy.GenerateName = fmt.Sprintf("%s-%s-", helmChartProxy.Spec.ChartName, cluster.Name)
@@ -220,7 +257,7 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 	} else {
 		helmReleaseProxy = existing
 		changed := false
-		if existing.Spec.Version != helmChartProxy.Spec.Version {
+		if existing.Spec.Version != version {
 			changed = true
 		}
 		if !cmp.Equal(existing.Spec.Values, parsedValues) {
@@ -233,7 +270,7 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 	}
 
 	helmReleaseProxy.Spec.ReconcileStrategy = helmChartProxy.Spec.ReconcileStrategy
-	helmReleaseProxy.Spec.Version = helmChartProxy.Spec.Version
+	helmReleaseProxy.Spec.Version = version
 	helmReleaseProxy.Spec.Values = parsedValues
 	helmReleaseProxy.Spec.Options = helmChartProxy.Spec.Options
 	helmReleaseProxy.Spec.Credentials = helmChartProxy.Spec.Credentials

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
@@ -286,24 +286,24 @@ var (
 			RepoURL:          "https://test-repo-url",
 			ReleaseNamespace: "test-release-namespace",
 			VersionMap: map[string]string{
-				"> v1.32":      "v0.32",
-				"v1.31":        "v0.31",
-				"v1.30":        "v0.30",
-				"v1.29":        "v0.29",
-				"v1.28":        "v0.28",
-				"v1.27":        "v0.27",
-				"v1.26":        "v0.26",
-				"v1.25":        "v0.25",
-				"v1.24":        "v0.24",
-				"v1.23":        "v0.23",
-				"v1.22":        "v0.22",
-				"v1.21":        "v0.21",
-				"v1.20":        "v0.20",
-				"v1.19":        "v0.19",
-				"v1.18":        "v0.18",
-				"v1.17":        "v0.10",
-				"v1.9 - v1.16": "v0.4 - v0.9",
-				"v1.7 - v1.8":  "v0.3.0",
+				"> 1.32":     "0.32",
+				"1.31":       "0.31",
+				"1.30":       "0.30",
+				"1.29":       "0.29",
+				"1.28":       "0.28",
+				"1.27":       "0.27",
+				"1.26":       "0.26",
+				"1.25":       "0.25",
+				"1.24":       "0.24",
+				"1.23":       "0.23",
+				"1.22":       "0.22",
+				"1.21":       "0.21",
+				"1.20":       "0.20",
+				"1.19":       "0.19",
+				"1.18":       "0.18",
+				"1.17":       "0.10",
+				"1.9 - 1.16": "0.4 - 0.9",
+				"1.7 - 1.8":  "0.3.0",
 			},
 			ValuesTemplate:    "apiServerPort: {{ .Cluster.spec.clusterNetwork.apiServerPort }}",
 			ReconcileStrategy: string(addonsv1alpha1.ReconcileStrategyContinuous),
@@ -696,54 +696,55 @@ func TestReconcileForCluster(t *testing.T) {
 	}
 }
 
-// func TestResolveKubernetesVersion(t *testing.T) {
-// 	t.Parallel()
+func TestResolveKubernetesVersion(t *testing.T) {
+	t.Parallel()
 
-// 	testcases := []struct {
-// 		name            string
-// 		helmChartProxy  *addonsv1alpha1.HelmChartProxy
-// 		cluster         *clusterv1.Cluster
-// 		controlPlane    client.Object
-// 		expectedVersion string
-// 		expectedError   string
-// 	}{
-// 		{
-// 			name:            "creates a HelmReleaseProxy for a HelmChartProxy",
-// 			helmChartProxy:  fakeVersionMapHelmChartProxy,
-// 			cluster:         fakeCluster1,
-// 			controlPlane:    fakeKubeadmControlPlane,
-// 			expectedVersion: "v0.21",
-// 			expectedError:   "",
-// 		},
-// 	}
+	testcases := []struct {
+		name            string
+		helmChartProxy  *addonsv1alpha1.HelmChartProxy
+		cluster         *clusterv1.Cluster
+		controlPlane    client.Object
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name:            "creates a HelmReleaseProxy for a HelmChartProxy",
+			helmChartProxy:  fakeVersionMapHelmChartProxy,
+			cluster:         fakeCluster1,
+			controlPlane:    fakeKubeadmControlPlane,
+			expectedVersion: "0.21",
+			expectedError:   "",
+		},
+		// TODO: add more tests
+	}
 
-// 	for _, tc := range testcases {
-// 		tc := tc
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			g := NewWithT(t)
-// 			t.Parallel()
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
 
-// 			objects := []client.Object{tc.helmChartProxy, tc.cluster, tc.controlPlane}
-// 			r := &HelmChartProxyReconciler{
-// 				Client: fake.NewClientBuilder().
-// 					WithScheme(fakeScheme).
-// 					WithObjects(objects...).
-// 					WithStatusSubresource(&addonsv1alpha1.HelmChartProxy{}).
-// 					WithStatusSubresource(&addonsv1alpha1.HelmReleaseProxy{}).
-// 					Build(),
-// 			}
-// 			version, err := r.resolveKubernetesVersion(ctx, tc.helmChartProxy, *tc.cluster)
+			objects := []client.Object{tc.helmChartProxy, tc.cluster, tc.controlPlane}
+			r := &HelmChartProxyReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(fakeScheme).
+					WithObjects(objects...).
+					WithStatusSubresource(&addonsv1alpha1.HelmChartProxy{}).
+					WithStatusSubresource(&addonsv1alpha1.HelmReleaseProxy{}).
+					Build(),
+			}
+			version, err := r.getHelmChartVersionForCluster(ctx, tc.helmChartProxy, tc.cluster)
 
-// 			if tc.expectedError != "" {
-// 				g.Expect(err).To(HaveOccurred())
-// 				g.Expect(err).To(MatchError(tc.expectedError), err.Error())
-// 			} else {
-// 				g.Expect(err).NotTo(HaveOccurred())
-// 				g.Expect(version).To(Equal(tc.expectedVersion))
-// 			}
-// 		})
-// 	}
-// }
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError), err.Error())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(version).To(Equal(tc.expectedVersion))
+			}
+		})
+	}
+}
 
 func TestConstructHelmReleaseProxy(t *testing.T) {
 	testCases := []struct {

--- a/controllers/helmchartproxy/helmchartproxy_controller_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 	addonsv1alpha1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kubeadmv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -731,5 +732,6 @@ func TestReconcileAfterMatchingClusterUnpaused(t *testing.T) {
 func init() {
 	_ = scheme.AddToScheme(fakeScheme)
 	_ = clusterv1.AddToScheme(fakeScheme)
+	_ = kubeadmv1.AddToScheme(fakeScheme)
 	_ = addonsv1alpha1.AddToScheme(fakeScheme)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.0
 toolchain go1.22.10
 
 require (
-	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.10
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/google/go-cmp v0.6.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
@@ -33,7 +34,6 @@ require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
-github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testMap = map[string]string{
+		"> 1.32":     "0.32.0",
+		"1.31":       "0.31.0",
+		"1.30.x":     "0.30.0",
+		"1.29":       "0.29.0",
+		"1.28":       "0.28.0",
+		"1.27":       "0.27.0",
+		"1.26":       "0.26.0",
+		"1.25":       "0.25.0",
+		"1.24":       "0.24.0",
+		"1.23":       "0.23.0",
+		"1.22":       "0.22.0",
+		"1.21":       "0.21.0",
+		"1.20":       "0.20.0",
+		"1.19":       "0.19.0",
+		"1.18":       "0.18.0",
+		"1.17":       "0.10.0",
+		"1.9 - 1.16": "0.9.0",
+		"1.7 - 1.8":  "0.3.0",
+	}
+)
+
+func TestResolveHelmChartVersion(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name              string
+		kubernetesVersion string
+		versionMap        map[string]string
+		expectedVersion   string
+		expectedError     string
+	}{
+		{
+			name:              "match exact minor version",
+			kubernetesVersion: "v1.31",
+			versionMap:        testMap,
+			expectedVersion:   "0.31.0",
+			expectedError:     "",
+		},
+		{
+			name:              "match wildcard patch version",
+			kubernetesVersion: "v1.30.1",
+			versionMap:        testMap,
+			expectedVersion:   "0.30.0",
+			expectedError:     "",
+		},
+		{
+			name:              "match version in range",
+			kubernetesVersion: "v1.10",
+			versionMap:        testMap,
+			expectedVersion:   "0.9.0",
+			expectedError:     "",
+		},
+		{
+			name:              "ensure range is inclusive",
+			kubernetesVersion: "v1.16",
+			versionMap:        testMap,
+			expectedVersion:   "0.9.0",
+			expectedError:     "",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			t.Parallel()
+
+			version, err := ResolveHelmChartVersion(tc.kubernetesVersion, tc.versionMap)
+
+			if tc.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(tc.expectedError), err.Error())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(version).To(Equal(tc.expectedVersion))
+			}
+		})
+	}
+}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -24,24 +24,24 @@ import (
 
 var (
 	testMap = map[string]string{
-		"> 1.32":     "0.32.0",
-		"1.31":       "0.31.0",
-		"1.30.x":     "0.30.0",
-		"1.29":       "0.29.0",
-		"1.28":       "0.28.0",
-		"1.27":       "0.27.0",
-		"1.26":       "0.26.0",
-		"1.25":       "0.25.0",
-		"1.24":       "0.24.0",
-		"1.23":       "0.23.0",
-		"1.22":       "0.22.0",
-		"1.21":       "0.21.0",
-		"1.20":       "0.20.0",
-		"1.19":       "0.19.0",
-		"1.18":       "0.18.0",
-		"1.17":       "0.10.0",
-		"1.9 - 1.16": "0.9.0",
-		"1.7 - 1.8":  "0.3.0",
+		"> 1.32":     "0.32",
+		"1.31":       "0.31",
+		"1.30.x":     "0.30",
+		"1.29":       "0.29",
+		"1.28":       "0.28",
+		"1.27":       "0.27",
+		"1.26":       "0.26",
+		"1.25":       "0.25",
+		"1.24":       "0.24",
+		"1.23":       "0.23",
+		"1.22":       "0.22",
+		"1.21":       "0.21",
+		"1.20":       "0.20",
+		"1.19":       "0.19",
+		"1.18":       "0.18",
+		"1.17":       "0.10",
+		"1.9 - 1.16": "0.4 - 0.9",
+		"1.7 - 1.8":  "0.3",
 	}
 )
 
@@ -59,30 +59,31 @@ func TestResolveHelmChartVersion(t *testing.T) {
 			name:              "match exact minor version",
 			kubernetesVersion: "v1.31",
 			versionMap:        testMap,
-			expectedVersion:   "0.31.0",
+			expectedVersion:   "0.31",
 			expectedError:     "",
 		},
 		{
 			name:              "match wildcard patch version",
 			kubernetesVersion: "v1.30.1",
 			versionMap:        testMap,
-			expectedVersion:   "0.30.0",
+			expectedVersion:   "0.30",
 			expectedError:     "",
 		},
 		{
 			name:              "match version in range",
 			kubernetesVersion: "v1.10",
 			versionMap:        testMap,
-			expectedVersion:   "0.9.0",
+			expectedVersion:   "0.4 - 0.9",
 			expectedError:     "",
 		},
 		{
 			name:              "ensure range is inclusive",
 			kubernetesVersion: "v1.16",
 			versionMap:        testMap,
-			expectedVersion:   "0.9.0",
+			expectedVersion:   "0.4 - 0.9",
 			expectedError:     "",
 		},
+		// TODO: add more tests
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Allows for users to specify a compatibility matrix so that a single HelmChartProxy can support multiple different Helm chart versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
