### PR TITLE
:bug: Update metadata for v0.3.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,3 +11,6 @@ releaseSeries:
   - major: 0
     minor: 2
     contract: v1beta1
+  - major: 0
+    minor: 3
+    contract: v1beta1


### PR DESCRIPTION
This PR updates the `metadata.yaml` file in order to avoid issues when using `clusterctl`.

For example:
```
$ clusterctl generate provider --addon helm:v0.3.0
Error: invalid provider metadata: version v0.3.0 for the provider helm does not match any release series
```