### PR TITLE
🐛 Update golangci-lint to v1.64.8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # tag=v6.5.2
         with:
-          version: v1.61.0
+          version: v1.64.8
           working-directory: ${{matrix.working-directory}}
           args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,13 +57,13 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - stylecheck
-    - tenv
     - testableexamples
     - thelper
     - tparallel
     - unconvert
     - unparam
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Somehow `golangci-lint` began failing in-place, even though the version was pinned. Updating to the latest v1.x release seems to fix it.

**Which issue(s) this PR fixes**:

Refs #386