### PR TITLE
:bug: get_go_version in Makefile is not supporting replace in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ _SKIP_ARGS := $(foreach arg,$(strip $(GINKGO_SKIP)),-skip="$(arg)")
 endif
 
 # Helper function to get dependency version from go.mod
-get_go_version = $(shell go list -f "{{.Version}}" -m $1)
+get_go_version = $(shell go list -m $1 | rev | cut -d' ' -f1 | rev)
 
 #
 # Binaries.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This is small fix to support replace in go.mod while getting module version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
