### PR TITLE
🌱 Bump golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # tag=v6.5.2
         with:
-          version: v1.64.8
+          version: v2.1.6
           working-directory: ${{matrix.working-directory}}
           args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,22 +1,10 @@
+version: "2"
 run:
-  timeout: 5m
   go: "1.22"
   allow-parallel-runners: true
-
 linters:
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  default: none
   enable:
-    # Default linters
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-    # Additional linters
     - asasalint
     - asciicheck
     - bidichk
@@ -26,23 +14,22 @@ linters:
     - copyloopvar
     - dogsled
     - durationcheck
+    - errcheck
     - errchkjson
     - errname
     - errorlint
     - exhaustive
     - forcetypeassert
-    - gci
     - ginkgolinter
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - goprintffuncname
+    - govet
     - importas
+    - ineffassign
     - makezero
     - misspell
     - nakedret
@@ -56,85 +43,97 @@ linters:
     - reassign
     - rowserrcheck
     - sqlclosecheck
-    - stylecheck
+    - staticcheck
     - testableexamples
     - thelper
     - tparallel
     - unconvert
     - unparam
+    - unused
     - usestdlibvars
     - usetesting
     - wastedassign
     - whitespace
+  settings:
+    goheader:
+      values:
+        regexp:
+          license-year: (202[0-9]|20[3-9][0-9])
+      template: |-
+        Copyright {{license-year}} The Kubernetes Authors.
 
-linters-settings:
-  goheader:
-    values:
-      regexp:
-        license-year: (202[0-9]|20[3-9][0-9])
-    template: |-
-      Copyright {{license-year}} The Kubernetes Authors.
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
 
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
+            http://www.apache.org/licenses/LICENSE-2.0
 
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-  nlreturn:
-    block-size: 2
-  stylecheck:
-    # https://staticcheck.io/docs/options#checks
-    checks: ["all", "-ST1000", "-ST1003", "-ST1016"]
-    dot-import-whitelist:
-      - "github.com/onsi/gomega"
-  importas:
-    no-unaliased: true
-    alias:
-      # Kubernetes
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: kerrors
-      - pkg: k8s.io/apimachinery/pkg/util/runtime
-        alias: utilruntime
-      # Controller Runtime
-      - pkg: sigs.k8s.io/controller-runtime
-        alias: ctrl
-      # CAPI
-      - pkg: sigs.k8s.io/cluster-api/api/v1beta1
-        alias: clusterv1
-      - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3
-        alias: clusterctlv1
-      - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/client/config
-        alias: configclient
-      # CAPI Add-on Provider Helm
-      - pkg: sigs.k8s.io/cluster-api-addon-provider-helm
-        alias: addonsv1alpha1
-issues:
-  exclude:
-    # Not all platforms are supported by this provider, those which aren't
-    # supported will be caught by the default case in the switches.
-    - "missing cases in switch of type v1.PlatformType: (\\.*)"
-  exclude-use-default: false
-  exclude-files:
-    - "zz_generated.*\\.go$"
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gosec
-    - path: hack/boilerplate
-      linters:
-        - goheader
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        - pkg: k8s.io/apimachinery/pkg/util/runtime
+          alias: utilruntime
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+          alias: clusterv1
+        - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3
+          alias: clusterctlv1
+        - pkg: sigs.k8s.io/cluster-api/cmd/clusterctl/client/config
+          alias: configclient
+        - pkg: sigs.k8s.io/cluster-api-addon-provider-helm
+          alias: addonsv1alpha1
+      no-unaliased: true
+    nlreturn:
+      block-size: 2
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1016
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+      - linters:
+          - goheader
+        path: hack/boilerplate
+      - path: (.+)\.go$
+        text: 'missing cases in switch of type v1.PlatformType: (\.*)'
+    paths:
+      - zz_generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -135,7 +135,7 @@ func (r *HelmChartProxyReconciler) getExistingHelmReleaseProxy(ctx context.Conte
 	// TODO: Figure out if we want this search to be cross-namespaces.
 
 	log.V(2).Info("Attempting to fetch existing HelmReleaseProxy with Cluster and HelmChartProxy labels", "cluster", cluster.Name, "helmChartProxy", helmChartProxy.Name)
-	if err := r.Client.List(ctx, helmReleaseProxyList, listOpts...); err != nil {
+	if err := r.List(ctx, helmReleaseProxyList, listOpts...); err != nil {
 		return nil, err
 	}
 
@@ -161,12 +161,12 @@ func (r *HelmChartProxyReconciler) createOrUpdateHelmReleaseProxy(ctx context.Co
 		return nil
 	}
 	if existing == nil {
-		if err := r.Client.Create(ctx, helmReleaseProxy); err != nil {
+		if err := r.Create(ctx, helmReleaseProxy); err != nil {
 			return errors.Wrapf(err, "failed to create HelmReleaseProxy '%s' for cluster: %s/%s", helmReleaseProxy.Name, cluster.Namespace, cluster.Name)
 		}
 	} else {
 		// TODO: should this use patchHelmReleaseProxy() instead of Update() in case there's a race condition?
-		if err := r.Client.Update(ctx, helmReleaseProxy); err != nil {
+		if err := r.Update(ctx, helmReleaseProxy); err != nil {
 			return errors.Wrapf(err, "failed to update HelmReleaseProxy '%s' for cluster: %s/%s", helmReleaseProxy.Name, cluster.Namespace, cluster.Name)
 		}
 	}
@@ -178,7 +178,7 @@ func (r *HelmChartProxyReconciler) createOrUpdateHelmReleaseProxy(ctx context.Co
 func (r *HelmChartProxyReconciler) deleteHelmReleaseProxy(ctx context.Context, helmReleaseProxy *addonsv1alpha1.HelmReleaseProxy) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	if err := r.Client.Delete(ctx, helmReleaseProxy); err != nil {
+	if err := r.Delete(ctx, helmReleaseProxy); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(2).Info("HelmReleaseProxy already deleted, nothing to do", "helmReleaseProxy", helmReleaseProxy.Name)
 			return nil

--- a/internal/helm_client.go
+++ b/internal/helm_client.go
@@ -213,7 +213,7 @@ func (c *HelmClient) InstallHelmRelease(ctx context.Context, restConfig *rest.Co
 	installClient.ReleaseName = spec.ReleaseName
 
 	log.V(2).Info("Locating chart...")
-	cp, err := installClient.ChartPathOptions.LocateChart(chartName, settings)
+	cp, err := installClient.LocateChart(chartName, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +371,7 @@ func (c *HelmClient) UpgradeHelmReleaseIfChanged(ctx context.Context, restConfig
 	upgradeClient.Namespace = spec.ReleaseNamespace
 
 	log.V(2).Info("Locating chart...")
-	cp, err := upgradeClient.ChartPathOptions.LocateChart(chartName, settings)
+	cp, err := upgradeClient.LocateChart(chartName, settings)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates golangci-lint to current version v2.1.6.

**Which issue(s) this PR fixes**:

See #394, which requires golangci-lint v2.x.
