### PR TITLE
:bug: Try to upgrade Releases in pending states

### DIFF
--- a/internal/helm_client_test.go
+++ b/internal/helm_client_test.go
@@ -23,6 +23,10 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"helm.sh/helm/v3/pkg/chart"
+	helmRelease "helm.sh/helm/v3/pkg/release"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
 )
 
 func TestNewDefaultRegistryClient(t *testing.T) {
@@ -99,6 +103,115 @@ func TestNewDefaultRegistryClient(t *testing.T) {
 			)
 			g.Expect(err).To(tc.assertErr)
 			g.Expect(client).To(tc.assertClient)
+		})
+	}
+}
+
+func TestShouldUpgradeHelmRelease(t *testing.T) {
+	deployed := &helmRelease.Info{
+		Status: helmRelease.StatusDeployed,
+	}
+	pending := &helmRelease.Info{
+		Status: helmRelease.StatusPendingInstall,
+	}
+	failed := &helmRelease.Info{
+		Status: helmRelease.StatusFailed,
+	}
+
+	chartV0 := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Version: "0.0.0",
+		},
+	}
+	chartV1 := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Version: "1.0.0",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		existing       helmRelease.Release
+		chartRequested *chart.Chart
+		values         map[string]any
+		expected       bool
+		expectedErr    error
+	}{
+		{
+			name:        "no existing chart",
+			existing:    helmRelease.Release{Chart: nil},
+			expectedErr: errNoChartVersion,
+		},
+		{
+			name: "updated chart version",
+			existing: helmRelease.Release{
+				Chart: chartV0,
+			},
+			chartRequested: chartV1,
+			expected:       true,
+		},
+		{
+			name: "existing failed status",
+			existing: helmRelease.Release{
+				Chart: chartV0,
+				Info:  failed,
+			},
+			chartRequested: chartV0,
+			expected:       true,
+		},
+		{
+			name: "existing pending status",
+			existing: helmRelease.Release{
+				Chart: chartV0,
+				Info:  pending,
+			},
+			chartRequested: chartV0,
+			expected:       true,
+		},
+		{
+			name: "identical values",
+			existing: helmRelease.Release{
+				Chart: chartV0,
+				Info:  deployed,
+				Config: map[string]any{
+					"key": float64(123),
+				},
+			},
+			chartRequested: chartV0,
+			values: map[string]any{
+				"key": 123,
+			},
+			expected: false,
+		},
+		{
+			name: "modified values",
+			existing: helmRelease.Release{
+				Chart: chartV0,
+				Info:  deployed,
+				Config: map[string]any{
+					"key": float64(123),
+				},
+			},
+			chartRequested: chartV0,
+			values: map[string]any{
+				"key": 456,
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, ctx := ktesting.NewTestContext(t)
+
+			actual, err := shouldUpgradeHelmRelease(ctx, test.existing, test.chartRequested, test.values)
+			if test.expectedErr != nil {
+				g.Expect(err).To(MatchError(test.expectedErr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(actual).To(Equal(test.expected))
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR makes CAAPH try to upgrade Releases in `pending-install` and `pending-upgrade` states, which could indicate that a previous attempt to install or upgrade had started and then failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #416
