### PR TITLE
:sparkles: :seedling: Add TakeOwnership optional flag to helm options

### DIFF
--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -159,6 +159,10 @@ type HelmOptions struct {
 	// +kubebuilder:default=false
 	// +optional
 	EnableClientCache bool `json:"enableClientCache,omitempty"`
+
+	// TakeOwnership represents CLI --take-ownership flag passed to Helm upgrade or install operation. If set, install will ignore the check for helm annotations and take ownership of the existing resources
+	// +optional
+	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
 type HelmInstallOptions struct {

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -191,6 +191,12 @@ spec:
                       By default, CRDs are installed if not already present.
                       If set, no CRDs will be installed.
                     type: boolean
+                  takeOwnership:
+                    description: TakeOwnership represents CLI --take-ownership flag
+                      passed to Helm upgrade or install operation. If set, install
+                      will ignore the check for helm annotations and take ownership
+                      of the existing resources
+                    type: boolean
                   timeout:
                     description: |-
                       Timeout is the time to wait for any individual Kubernetes operation (like

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
@@ -197,6 +197,12 @@ spec:
                       By default, CRDs are installed if not already present.
                       If set, no CRDs will be installed.
                     type: boolean
+                  takeOwnership:
+                    description: TakeOwnership represents CLI --take-ownership flag
+                      passed to Helm upgrade or install operation. If set, install
+                      will ignore the check for helm annotations and take ownership
+                      of the existing resources
+                    type: boolean
                   timeout:
                     description: |-
                       Timeout is the time to wait for any individual Kubernetes operation (like

--- a/internal/helm_client.go
+++ b/internal/helm_client.go
@@ -139,6 +139,7 @@ func generateHelmInstallConfig(actionConfig *helmAction.Configuration, helmOptio
 	installClient.Atomic = helmOptions.Atomic
 	installClient.IncludeCRDs = helmOptions.Install.IncludeCRDs
 	installClient.CreateNamespace = helmOptions.Install.CreateNamespace
+	installClient.TakeOwnership = helmOptions.TakeOwnership
 
 	return installClient
 }
@@ -169,6 +170,7 @@ func generateHelmUpgradeConfig(actionConfig *helmAction.Configuration, helmOptio
 	upgradeClient.ResetThenReuseValues = helmOptions.Upgrade.ResetThenReuseValues
 	upgradeClient.MaxHistory = helmOptions.Upgrade.MaxHistory
 	upgradeClient.CleanupOnFail = helmOptions.Upgrade.CleanupOnFail
+	upgradeClient.TakeOwnership = helmOptions.TakeOwnership
 
 	return upgradeClient
 }


### PR DESCRIPTION
Adds TakeOwnership flag to helm install/upgrade

Fixes https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/issues/345