### PR TITLE
🌱 Prefer go.mod's version of Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ TILT_PREPARE := $(abspath $(TOOLS_BIN_DIR)/$(TILT_PREPARE_BIN))
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN))
 
-HELM_VER := v3.14.4
+HELM_VER := $(call get_go_version,helm.sh/helm/v3)
 HELM_BIN := helm
 HELM := $(TOOLS_BIN_DIR)/$(HELM_BIN)-$(HELM_VER)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The version of Helm vendored into `go.mod` and the one specified in the `Makefile` differed (v3.14.4 vs. v3.16.4). This keeps them in sync.

**Which issue(s) this PR fixes**:

Fixes #
