### PR TITLE
🌱 Fix USER_FORK definition in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,7 @@ RELEASE_NOTES_DIR := _releasenotes
 GIT_REPO_NAME ?= cluster-api-addon-provider-helm
 GIT_ORG_NAME ?= kubernetes-sigs
 USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4) # only works on https://github.com/<username>/cluster-api-addon-provider-helm.git style URLs
-ifdef USER_FORK
+ifeq ($(USER_FORK),)
 USER_FORK := $(shell git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1) # for git@github.com:<username>/cluster-api-addon-provider-helm.git style URLs
 endif
 IMAGE_REVIEWERS ?= $(shell ./hack/get-project-maintainers.sh)


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a bug in the Makefile that effectively made `make promote-images` fail with a https:// git remote to kubernetes/k8s,io.

**Which issue(s) this PR fixes**:
