### PR TITLE
:bug: add 0.4 for metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,3 +15,6 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**: With the 0.4.0 release yesterday, the add-on is having issues installing for the latest version since the metadata.yaml wasn't updated for the new minor version:
```
capi-control… │ Fetching providers
capi-control… │ Error: invalid provider metadata: version v0.4.0 for the provider caaph-system/addon-helm does not match any release series. Available series: [0.1, 0.2, 0.3]. This usually means the release tag lacks an updated metadata.yaml or the repository URL is stale.
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
