### PR TITLE
🌱 Bump hack/tools/go.mod and GH actions to Go 1.24

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
       with:
-        go-version: '1.23'
+        go-version: '1.24'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # tag=v6.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # tag=v6.1.0
         with:
-          go-version: '^1.23'
+          go-version: '^1.24'
       - name: generate release artifacts
         run: |
           make release

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-addon-provider-helm
 
 go 1.24.0
 
-toolchain go1.24.7
+toolchain go1.24.10
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-provider-azure/hack/tools
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.12
+toolchain go1.24.10
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Follows up on #438 to bump the Go toolchain version to current patch of v1.24 in some places other than the main `go.mod`.

**Which issue(s) this PR fixes**:

Fixes #458
