### PR TITLE
🐛 Add new version 0.5 with contract v1beta2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,3 +18,6 @@ releaseSeries:
   - major: 0
     minor: 4
     contract: v1beta1
+  - major: 0
+    minor: 5
+    contract: v1beta2


### PR DESCRIPTION
**What this PR does / why we need it**: With the 0.5.0 release an hour ago, the add-on is having issues installing for the latest version since the metadata.yaml wasn't updated for the new minor version:
```
capi-control… │ Fetching providers
capi-control… │ Error: invalid provider metadata: version v0.5.0 for the provider caaph-system/addon-helm does not match any release series. Available series: [0.1, 0.2, 0.3, 0.4]. This usually means the release tag lacks an updated metadata.yaml or the repository URL is stale.
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #