### PR TITLE
🌱 Pin actions/checkout to SHA in yamlvalidator workflow

### DIFF
--- a/.github/workflows/yamlvalidator.yml
+++ b/.github/workflows/yamlvalidator.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
 
       - name: Lint YAML files
         run: yamllint -c .github/yamllint_config.yaml .


### PR DESCRIPTION
**What this PR does / why we need it**:

Pins the actions/checkout GH action to a SHA, as per Kubernetes org policy.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/actions/runs/24667341684/job/72128339044, for example.
