### PR TITLE
🌱 Update GCB image and machine type in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,9 +3,9 @@
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:8d6a3a5b895e6776dbe9115b75db1412fbe57299b8db329d45cb54680e462b0b' # v20251211-4c812d4cd8
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**What this PR does / why we need it**:

Update gcb-docker-gcloud to v20251211-4c812d4cd8 (pinned by digest) and switch machine type from N1_HIGHCPU_8 to E2_HIGHCPU_8 (which all other cluster-api-* projects seem to be using).

The old image does not support Go 1.25, which is required by go.mod, causing staging image builds to fail.

**Which issue(s) this PR fixes**:

See https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-cluster-api-addon-provider-helm-push-images
