### PR TITLE
🌱 Pin tigera-operator chart version in e2e templates

### DIFF
--- a/test/e2e/data/addons-helm/v1beta2/bases/calico.yaml
+++ b/test/e2e/data/addons-helm/v1beta2/bases/calico.yaml
@@ -10,6 +10,7 @@ spec:
   chartName: tigera-operator
   releaseName: projectcalico
   namespace: tigera-operator
+  version: v3.31.4
   valuesTemplate: |
     installation:
       cni:

--- a/test/e2e/data/addons-helm/v1beta2/cluster-template-upgrades.yaml
+++ b/test/e2e/data/addons-helm/v1beta2/cluster-template-upgrades.yaml
@@ -10,6 +10,7 @@ spec:
   namespace: tigera-operator
   releaseName: projectcalico
   repoURL: https://docs.tigera.io/calico/charts
+  version: v3.31.4
   valuesTemplate: |
     installation:
       cni:

--- a/test/e2e/data/addons-helm/v1beta2/cluster-template.yaml
+++ b/test/e2e/data/addons-helm/v1beta2/cluster-template.yaml
@@ -10,6 +10,7 @@ spec:
   namespace: tigera-operator
   releaseName: projectcalico
   repoURL: https://docs.tigera.io/calico/charts
+  version: v3.31.4
   valuesTemplate: |
     installation:
       cni:


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e cluster templates create a HelmChartProxy for tigera-operator without pinning spec.version, which causes the latest published chart to be installed on each run. Chart v3.31.5 (published 2026-04-15) broke the install (the tigera-operator Deployment is never created), which has caused caaph-periodic-e2e-main and every PR e2e job to fail since 2026-04-19.

Pin to v3.31.4 (last known-good release) to unblock CI.

**Which issue(s) this PR fixes**:

Fixes #
