### PR TITLE
🌱 Bump golangci-lint to v2.12.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,6 +27,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # tag=v9.2.0
         with:
-          version: v2.7.0
+          version: v2.12.1
           working-directory: ${{matrix.working-directory}}
           args: --timeout=5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,6 +113,7 @@ linters:
     rules:
       - linters:
           - gosec
+          - goconst
         path: _test\.go
       - linters:
           - goheader

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -296,7 +296,7 @@ func shouldReinstallHelmRelease(ctx context.Context, existing *addonsv1alpha1.He
 	annotations := existing.GetAnnotations()
 	result, ok := annotations[addonsv1alpha1.IsReleaseNameGeneratedAnnotation]
 
-	isReleaseNameGenerated := ok && result == "true"
+	isReleaseNameGenerated := ok && result == "true" //nolint:goconst
 	switch {
 	case existing.Spec.ChartName != helmChartProxy.Spec.ChartName:
 		log.V(2).Info("ChartName changed", "existing", existing.Spec.ChartName, "helmChartProxy", helmChartProxy.Spec.ChartName)

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
@@ -323,7 +323,7 @@ func (r *HelmReleaseProxyReconciler) reconcileNormal(ctx context.Context, helmRe
 
 	// TODO: add this here or in HelmChartProxy controller?
 	if helmReleaseProxy.Spec.ReleaseName == "" {
-		annotations[addonsv1alpha1.IsReleaseNameGeneratedAnnotation] = "true"
+		annotations[addonsv1alpha1.IsReleaseNameGeneratedAnnotation] = "true" //nolint:goconst
 		helmReleaseProxy.SetAnnotations(annotations)
 	}
 

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -367,7 +367,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps golangci-lint to the current version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
