### PR TITLE
🌱 Bump Go toolchain to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-addon-provider-helm
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/cluster-api-addon-provider-helm/hack/tools
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require github.com/hashicorp/go-multierror v1.1.1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The weekly security scan is failing because govulncheck reports 6 Go stdlib CVEs against go1.25.9 (in `net`, `net/http`, `net/mail`, `html/template`), all fixed in go1.25.10. Bumps the `toolchain` directive in both `go.mod` files.

**Which issue(s) this PR fixes**:

N/A

**Additional comments for reviewers**:
`make verify-govulncheck` is clean locally after the bump.