### PR TITLE
🌱 Fix verify-govulncheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,12 +398,7 @@ verify-container-images: ## Verify container images
 
 .PHONY: verify-govulncheck
 verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
-	$(GOVULNCHECK) ./... && R1=$$? || R1=$$?; \
-	$(GOVULNCHECK) -C "$(TOOLS_DIR)" ./... && R2=$$? || R2=$$?; \
-	$(GOVULNCHECK) -C "$(TEST_DIR)" ./... && R3=$$? || R3=$$?; \
-	if [ "$$R1" -ne "0" ] || [ "$$R2" -ne "0" ] || [ "$$R3" -ne "0" ]; then \
-		exit 1; \
-	fi
+	$(GOVULNCHECK) ./...
 
 .PHONY: verify-security
 verify-security: ## Verify code and images for vulnerabilities


### PR DESCRIPTION
**What this PR does / why we need it**:

After bumping govulncheck to v1.3.0, the weekly security scan still fails with `govulncheck: no packages matched the provided patterns`. v1.3.0 now exits non-zero in that case (v1.1.4 returned 0).

The Makefile target ran govulncheck against three paths:
- `./...` — OK
- `-C hack/tools ./...` — fails: only a build-tagged `tools.go` lives there
- `-C test ./...` — fails: CAAPH has no `test/go.mod` (unlike CAPI)

This was carried over from CAPI's Makefile where both subdirectories are real Go modules. Drop the two invocations so the target reflects CAAPH's actual module layout.

**Which issue(s) this PR fixes**:

N/A

**Additional comments for reviewers**:

`make verify-govulncheck` is clean locally after the change.