### PR TITLE
🌱 Bump Go to 1.26

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # tag=v6.5.0
       with:
-        go-version: '1.25'
+        go-version: '1.26'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # tag=v6.5.0
         with:
-          go-version: '^1.25'
+          go-version: '^1.26'
       - name: generate release artifacts
         run: |
           make release

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-addon-provider-helm
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cluster-api-addon-provider-helm/hack/tools
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.11
+toolchain go1.26.4
 
 require github.com/hashicorp/go-multierror v1.1.1
 


### PR DESCRIPTION
Bumps the Go directive to 1.26.0 and toolchain to go1.26.4 (both go.mod files), plus CI go-version pins. Matches CAPI, which is on the Go 1.26 series, and unblocks the helm v3.21.2 bump (#564), which requires Go >= 1.26.