### PR TITLE
🌱 Restrict Helm repository URL schemes

### DIFF
--- a/api/v1alpha1/helmchartproxy_url_test.go
+++ b/api/v1alpha1/helmchartproxy_url_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRepoURLValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		repoURL   string
+		expectErr bool
+	}{
+		{name: "https is allowed", repoURL: "https://charts.example.com/stable"},
+		{name: "oci is allowed", repoURL: "oci://registry.example.com/charts"},
+		{name: "uppercase scheme is allowed", repoURL: "HTTPS://charts.example.com"},
+		{name: "http is rejected", repoURL: "http://charts.example.com", expectErr: true},
+		{name: "ftp is rejected", repoURL: "ftp://charts.example.com", expectErr: true},
+		{name: "file is rejected", repoURL: "file:///etc/passwd", expectErr: true},
+		{name: "bare path is rejected", repoURL: "/some/local/path", expectErr: true},
+		{name: "missing host is rejected", repoURL: "https:///charts", expectErr: true},
+		{name: "empty URL is rejected", repoURL: "", expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			err := isUrlValid(tc.repoURL)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/api/v1alpha1/helmchartproxy_url_test.go
+++ b/api/v1alpha1/helmchartproxy_url_test.go
@@ -32,12 +32,15 @@ func TestRepoURLValidation(t *testing.T) {
 	}{
 		{name: "https is allowed", repoURL: "https://charts.example.com/stable"},
 		{name: "oci is allowed", repoURL: "oci://registry.example.com/charts"},
-		{name: "uppercase scheme is allowed", repoURL: "HTTPS://charts.example.com"},
+		{name: "uppercase https scheme is allowed", repoURL: "HTTPS://charts.example.com"},
+		{name: "uppercase oci scheme is rejected", repoURL: "OCI://registry.example.com/charts", expectErr: true},
 		{name: "http is rejected", repoURL: "http://charts.example.com", expectErr: true},
 		{name: "ftp is rejected", repoURL: "ftp://charts.example.com", expectErr: true},
 		{name: "file is rejected", repoURL: "file:///etc/passwd", expectErr: true},
 		{name: "bare path is rejected", repoURL: "/some/local/path", expectErr: true},
 		{name: "missing host is rejected", repoURL: "https:///charts", expectErr: true},
+		{name: "https port without host is rejected", repoURL: "https://:443/charts", expectErr: true},
+		{name: "oci port without host is rejected", repoURL: "oci://:443/charts", expectErr: true},
 		{name: "empty URL is rejected", repoURL: "", expectErr: true},
 	}
 

--- a/api/v1alpha1/helmchartproxy_webhook.go
+++ b/api/v1alpha1/helmchartproxy_webhook.go
@@ -130,12 +130,16 @@ func isUrlValid(repoURL string) error {
 	}
 
 	switch strings.ToLower(parsedURL.Scheme) {
-	case "https", "oci":
+	case "https":
+	case "oci":
+		if !strings.HasPrefix(repoURL, "oci://") {
+			return fmt.Errorf("specified repoURL %s must use the lowercase oci scheme", repoURL)
+		}
 	default:
 		return fmt.Errorf("specified repoURL %s uses unsupported scheme %q; supported schemes are https and oci", repoURL, parsedURL.Scheme)
 	}
 
-	if parsedURL.Host == "" {
+	if parsedURL.Hostname() == "" {
 		return fmt.Errorf("specified repoURL %s must include a host", repoURL)
 	}
 

--- a/api/v1alpha1/helmchartproxy_webhook.go
+++ b/api/v1alpha1/helmchartproxy_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -121,10 +122,21 @@ func (*helmChartProxyWebhook) ValidateDelete(_ context.Context, obj *HelmChartPr
 	return nil, nil
 }
 
-// isUrlValid returns true if specified repoURL is valid as per go doc https://pkg.go.dev/net/url#ParseRequestURI.
+// isUrlValid returns an error unless repoURL is an absolute HTTPS or OCI URL.
 func isUrlValid(repoURL string) error {
-	if _, err := url.ParseRequestURI(repoURL); err != nil {
+	parsedURL, err := url.ParseRequestURI(repoURL)
+	if err != nil {
 		return fmt.Errorf("specified repoURL %s is not valid: %w", repoURL, err)
+	}
+
+	switch strings.ToLower(parsedURL.Scheme) {
+	case "https", "oci":
+	default:
+		return fmt.Errorf("specified repoURL %s uses unsupported scheme %q; supported schemes are https and oci", repoURL, parsedURL.Scheme)
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("specified repoURL %s must include a host", repoURL)
 	}
 
 	return nil

--- a/api/v1alpha1/helmreleaseproxy_webhook.go
+++ b/api/v1alpha1/helmreleaseproxy_webhook.go
@@ -66,7 +66,10 @@ func (*helmReleaseProxyWebhook) Default(_ context.Context, obj *HelmReleaseProxy
 func (*helmReleaseProxyWebhook) ValidateCreate(_ context.Context, newObj *HelmReleaseProxy) (admission.Warnings, error) {
 	helmreleaseproxylog.Info("validate create", "name", newObj.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if err := isUrlValid(newObj.Spec.RepoURL); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 

--- a/api/v1alpha1/helmreleaseproxy_webhook_test.go
+++ b/api/v1alpha1/helmreleaseproxy_webhook_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHelmReleaseProxyValidateCreateRepoURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		repoURL   string
+		expectErr bool
+	}{
+		{name: "https URL is allowed", repoURL: "https://charts.example.com/stable"},
+		{name: "oci URL is allowed", repoURL: "oci://registry.example.com/charts"},
+		{name: "http URL is rejected", repoURL: "http://charts.example.com", expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			proxy := &HelmReleaseProxy{Spec: HelmReleaseProxySpec{RepoURL: tc.repoURL}}
+
+			_, err := (&helmReleaseProxyWebhook{}).ValidateCreate(context.Background(), proxy)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves Helm repository URL validation by allowing HTTPS and OCI URLs and rejecting unsupported or incomplete values. Adds focused regression coverage.
