### PR TITLE
🌱 Restrict Secret references to proxy namespaces

### DIFF
--- a/api/v1alpha1/helmchartproxy_secret_references_test.go
+++ b/api/v1alpha1/helmchartproxy_secret_references_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecretReferenceValidation(t *testing.T) {
+	t.Parallel()
+
+	newProxy := func(credentialsNamespace, caNamespace string) *HelmChartProxy {
+		proxy := &HelmChartProxy{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "tenant-a"},
+		}
+		if credentialsNamespace != "-" {
+			proxy.Spec.Credentials = &Credentials{
+				Secret: corev1.SecretReference{Name: "credentials", Namespace: credentialsNamespace},
+				Key:    "config.json",
+			}
+		}
+		if caNamespace != "-" {
+			proxy.Spec.TLSConfig = &TLSConfig{
+				CASecretRef: &corev1.SecretReference{Name: "ca", Namespace: caNamespace},
+			}
+		}
+
+		return proxy
+	}
+
+	testCases := []struct {
+		name      string
+		proxy     *HelmChartProxy
+		expectErr bool
+	}{
+		{name: "no secret references", proxy: newProxy("-", "-")},
+		{name: "empty credentials namespace", proxy: newProxy("", "-")},
+		{name: "matching credentials namespace", proxy: newProxy("tenant-a", "-")},
+		{name: "foreign credentials namespace", proxy: newProxy("kube-system", "-"), expectErr: true},
+		{name: "empty CA namespace", proxy: newProxy("-", "")},
+		{name: "matching CA namespace", proxy: newProxy("-", "tenant-a")},
+		{name: "foreign CA namespace", proxy: newProxy("-", "kube-system"), expectErr: true},
+		{name: "both foreign", proxy: newProxy("kube-system", "kube-system"), expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			allErrs := validateSecretReferences(tc.proxy)
+			if tc.expectErr {
+				g.Expect(allErrs).NotTo(BeEmpty())
+			} else {
+				g.Expect(allErrs).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestWebhookRejectsForeignSecretReferences(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	proxy := &HelmChartProxy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "tenant-a"},
+		Spec: HelmChartProxySpec{
+			RepoURL: "https://charts.example.com",
+			Credentials: &Credentials{
+				Secret: corev1.SecretReference{Name: "credentials", Namespace: "tenant-b"},
+			},
+		},
+	}
+	webhook := &helmChartProxyWebhook{}
+
+	_, err := webhook.ValidateCreate(context.Background(), proxy)
+	g.Expect(err).To(HaveOccurred())
+
+	oldProxy := proxy.DeepCopy()
+	oldProxy.Spec.Credentials.Secret.Namespace = oldProxy.Namespace
+	_, err = webhook.ValidateUpdate(context.Background(), oldProxy, proxy)
+	g.Expect(err).To(HaveOccurred())
+}

--- a/api/v1alpha1/helmchartproxy_types.go
+++ b/api/v1alpha1/helmchartproxy_types.go
@@ -224,7 +224,7 @@ type HelmUninstallOptions struct {
 }
 
 type Credentials struct {
-	// Secret is a reference to a Secret containing the OCI credentials.
+	// Secret is a reference to a Secret containing the OCI credentials. The Secret must be in the same namespace as the proxy.
 	Secret corev1.SecretReference `json:"secret"`
 
 	// Key is the key in the Secret containing the OCI credentials.
@@ -233,7 +233,7 @@ type Credentials struct {
 
 // TLSConfig defines a TLS configuration.
 type TLSConfig struct {
-	// Secret is a reference to a Secret containing the TLS CA certificate at the key ca.crt.
+	// Secret is a reference to a Secret containing the TLS CA certificate at the key ca.crt. The Secret must be in the same namespace as the proxy.
 	// +optional
 	CASecretRef *corev1.SecretReference `json:"caSecret,omitempty"`
 

--- a/api/v1alpha1/helmchartproxy_webhook.go
+++ b/api/v1alpha1/helmchartproxy_webhook.go
@@ -82,6 +82,9 @@ func (*helmChartProxyWebhook) ValidateCreate(_ context.Context, newObj *HelmChar
 	if err := isUrlValid(newObj.Spec.RepoURL); err != nil {
 		return nil, err
 	}
+	if allErrs := validateSecretReferences(newObj); len(allErrs) > 0 {
+		return nil, apierrors.NewInvalid(GroupVersion.WithKind("HelmChartProxy").GroupKind(), newObj.Name, allErrs)
+	}
 
 	return nil, nil
 }
@@ -98,6 +101,7 @@ func (*helmChartProxyWebhook) ValidateUpdate(_ context.Context, oldObj, newObj *
 				newObj.Spec.ReleaseNamespace, err.Error()),
 		)
 	}
+	allErrs = append(allErrs, validateSecretReferences(newObj)...)
 
 	if newObj.Spec.ReconcileStrategy != oldObj.Spec.ReconcileStrategy {
 		allErrs = append(allErrs,
@@ -128,4 +132,33 @@ func isUrlValid(repoURL string) error {
 	}
 
 	return nil
+}
+
+// validateSecretReferences ensures that a HelmChartProxy can only reference
+// credential and CA Secrets in its own namespace.
+func validateSecretReferences(helmChartProxy *HelmChartProxy) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if credentials := helmChartProxy.Spec.Credentials; credentials != nil &&
+		credentials.Secret.Namespace != "" &&
+		credentials.Secret.Namespace != helmChartProxy.Namespace {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "credentials", "secret", "namespace"),
+			credentials.Secret.Namespace,
+			"must be empty or match metadata.namespace",
+		))
+	}
+
+	if tlsConfig := helmChartProxy.Spec.TLSConfig; tlsConfig != nil &&
+		tlsConfig.CASecretRef != nil &&
+		tlsConfig.CASecretRef.Namespace != "" &&
+		tlsConfig.CASecretRef.Namespace != helmChartProxy.Namespace {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec", "tlsConfig", "caSecret", "namespace"),
+			tlsConfig.CASecretRef.Namespace,
+			"must be empty or match metadata.namespace",
+		))
+	}
+
+	return allErrs
 }

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmchartproxies.yaml
@@ -115,7 +115,8 @@ spec:
                     type: string
                   secret:
                     description: Secret is a reference to a Secret containing the
-                      OCI credentials.
+                      OCI credentials. The Secret must be in the same namespace as
+                      the proxy.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -290,7 +291,8 @@ spec:
                 properties:
                   caSecret:
                     description: Secret is a reference to a Secret containing the
-                      TLS CA certificate at the key ca.crt.
+                      TLS CA certificate at the key ca.crt. The Secret must be in
+                      the same namespace as the proxy.
                     properties:
                       name:
                         description: name is unique within a namespace to reference

--- a/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_helmreleaseproxies.yaml
@@ -121,7 +121,8 @@ spec:
                     type: string
                   secret:
                     description: Secret is a reference to a Secret containing the
-                      OCI credentials.
+                      OCI credentials. The Secret must be in the same namespace as
+                      the proxy.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -296,7 +297,8 @@ spec:
                 properties:
                   caSecret:
                     description: Secret is a reference to a Secret containing the
-                      TLS CA certificate at the key ca.crt.
+                      TLS CA certificate at the key ca.crt. The Secret must be in
+                      the same namespace as the proxy.
                     properties:
                       name:
                         description: name is unique within a namespace to reference

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases.go
@@ -251,6 +251,13 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 		if !cmp.Equal(existing.Spec.Values, parsedValues) {
 			changed = true
 		}
+		if existing.Spec.Credentials != nil && existing.Spec.Credentials.Secret.Namespace != helmChartProxy.Namespace {
+			changed = true
+		}
+		if existing.Spec.TLSConfig != nil && existing.Spec.TLSConfig.CASecretRef != nil &&
+			existing.Spec.TLSConfig.CASecretRef.Namespace != helmChartProxy.Namespace {
+			changed = true
+		}
 
 		if !changed {
 			return nil
@@ -261,13 +268,11 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 	helmReleaseProxy.Spec.Version = helmChartProxy.Spec.Version
 	helmReleaseProxy.Spec.Values = parsedValues
 	helmReleaseProxy.Spec.Options = helmChartProxy.Spec.Options
-	helmReleaseProxy.Spec.Credentials = helmChartProxy.Spec.Credentials
+	helmReleaseProxy.Spec.Credentials = helmChartProxy.Spec.Credentials.DeepCopy()
 
 	if helmReleaseProxy.Spec.Credentials != nil {
-		// If the namespace is not set, set it to the namespace of the HelmChartProxy
-		if helmReleaseProxy.Spec.Credentials.Secret.Namespace == "" {
-			helmReleaseProxy.Spec.Credentials.Secret.Namespace = helmChartProxy.Namespace
-		}
+		// Credentials Secrets are always resolved in the HelmChartProxy namespace.
+		helmReleaseProxy.Spec.Credentials.Secret.Namespace = helmChartProxy.Namespace
 
 		// If the key is not set, set it to the default key
 		if helmReleaseProxy.Spec.Credentials.Key == "" {
@@ -275,13 +280,11 @@ func constructHelmReleaseProxy(existing *addonsv1alpha1.HelmReleaseProxy, helmCh
 		}
 	}
 
-	helmReleaseProxy.Spec.TLSConfig = helmChartProxy.Spec.TLSConfig
+	helmReleaseProxy.Spec.TLSConfig = helmChartProxy.Spec.TLSConfig.DeepCopy()
 
 	if helmReleaseProxy.Spec.TLSConfig != nil && helmReleaseProxy.Spec.TLSConfig.CASecretRef != nil {
-		// If the namespace is not set, set it to the namespace of the HelmChartProxy
-		if helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace == "" {
-			helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace = helmChartProxy.Namespace
-		}
+		// CA Secrets are always resolved in the HelmChartProxy namespace.
+		helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace = helmChartProxy.Namespace
 	}
 
 	return helmReleaseProxy

--- a/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
+++ b/controllers/helmchartproxy/helmchartproxy_controller_phases_test.go
@@ -1103,7 +1103,7 @@ func TestConstructHelmReleaseProxy(t *testing.T) {
 			},
 		},
 		{
-			name:     "construct helm release proxy with secret and custom namespace",
+			name:     "construct helm release proxy replaces foreign secret namespace",
 			existing: nil,
 			helmChartProxy: &addonsv1alpha1.HelmChartProxy{
 				TypeMeta: metav1.TypeMeta{
@@ -1181,7 +1181,7 @@ func TestConstructHelmReleaseProxy(t *testing.T) {
 					Credentials: &addonsv1alpha1.Credentials{
 						Secret: corev1.SecretReference{
 							Name:      "test-secret",
-							Namespace: "my-namespace",
+							Namespace: "test-namespace",
 						},
 						Key: "config.json",
 					},
@@ -1364,6 +1364,62 @@ func TestConstructHelmReleaseProxy(t *testing.T) {
 			g.Expect(diff).To(BeEmpty())
 		})
 	}
+}
+
+func TestConstructHelmReleaseProxyRestrictsSecretNamespaces(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	helmChartProxy := &addonsv1alpha1.HelmChartProxy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "tenant-a"},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			Credentials: &addonsv1alpha1.Credentials{
+				Secret: corev1.SecretReference{Name: "credentials", Namespace: "tenant-b"},
+			},
+			TLSConfig: &addonsv1alpha1.TLSConfig{
+				CASecretRef: &corev1.SecretReference{Name: "ca", Namespace: "tenant-b"},
+			},
+		},
+	}
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+
+	result := constructHelmReleaseProxy(nil, helmChartProxy, "", cluster)
+
+	g.Expect(result.Spec.Credentials.Secret.Namespace).To(Equal(helmChartProxy.Namespace))
+	g.Expect(result.Spec.TLSConfig.CASecretRef.Namespace).To(Equal(helmChartProxy.Namespace))
+	g.Expect(helmChartProxy.Spec.Credentials.Secret.Namespace).To(Equal("tenant-b"))
+	g.Expect(helmChartProxy.Spec.TLSConfig.CASecretRef.Namespace).To(Equal("tenant-b"))
+}
+
+func TestConstructHelmReleaseProxyCorrectsExistingSecretNamespaces(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	helmChartProxy := &addonsv1alpha1.HelmChartProxy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "tenant-a"},
+		Spec: addonsv1alpha1.HelmChartProxySpec{
+			Credentials: &addonsv1alpha1.Credentials{
+				Secret: corev1.SecretReference{Name: "credentials", Namespace: "tenant-b"},
+			},
+			TLSConfig: &addonsv1alpha1.TLSConfig{
+				CASecretRef: &corev1.SecretReference{Name: "ca", Namespace: "tenant-b"},
+			},
+		},
+	}
+	existing := &addonsv1alpha1.HelmReleaseProxy{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "tenant-a"},
+		Spec: addonsv1alpha1.HelmReleaseProxySpec{
+			Credentials: helmChartProxy.Spec.Credentials.DeepCopy(),
+			TLSConfig:   helmChartProxy.Spec.TLSConfig.DeepCopy(),
+		},
+	}
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+
+	result := constructHelmReleaseProxy(existing, helmChartProxy, "", cluster)
+
+	g.Expect(result).NotTo(BeNil())
+	g.Expect(result.Spec.Credentials.Secret.Namespace).To(Equal(helmChartProxy.Namespace))
+	g.Expect(result.Spec.TLSConfig.CASecretRef.Namespace).To(Equal(helmChartProxy.Namespace))
 }
 
 func TestShouldReinstallHelmRelease(t *testing.T) {

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller.go
@@ -490,11 +490,7 @@ func patchHelmReleaseProxy(ctx context.Context, patchHelper *patch.Helper, helmR
 func (r *HelmReleaseProxyReconciler) getCredentials(ctx context.Context, helmReleaseProxy *addonsv1alpha1.HelmReleaseProxy) (string, error) {
 	credentialsPath := ""
 	if helmReleaseProxy.Spec.Credentials != nil && helmReleaseProxy.Spec.Credentials.Secret.Name != "" {
-		// By default, the secret is in the same namespace as the HelmReleaseProxy
-		if helmReleaseProxy.Spec.Credentials.Secret.Namespace == "" {
-			helmReleaseProxy.Spec.Credentials.Secret.Namespace = helmReleaseProxy.Namespace
-		}
-		credentialsValues, err := r.getCredentialsFromSecret(ctx, helmReleaseProxy.Spec.Credentials.Secret.Name, helmReleaseProxy.Spec.Credentials.Secret.Namespace, helmReleaseProxy.Spec.Credentials.Key)
+		credentialsValues, err := r.getCredentialsFromSecret(ctx, helmReleaseProxy.Spec.Credentials.Secret.Name, helmReleaseProxy.Namespace, helmReleaseProxy.Spec.Credentials.Key)
 		if err != nil {
 			return "", err
 		}
@@ -517,11 +513,7 @@ func (r *HelmReleaseProxyReconciler) getCAFile(ctx context.Context, helmReleaseP
 	if helmReleaseProxy.Spec.TLSConfig != nil &&
 		helmReleaseProxy.Spec.TLSConfig.CASecretRef != nil &&
 		helmReleaseProxy.Spec.TLSConfig.CASecretRef.Name != "" {
-		// By default, the secret is in the same namespace as the HelmReleaseProxy
-		if helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace == "" {
-			helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace = helmReleaseProxy.Namespace
-		}
-		caSecretValues, err := r.getCACertificateFromSecret(ctx, helmReleaseProxy.Spec.TLSConfig.CASecretRef.Name, helmReleaseProxy.Spec.TLSConfig.CASecretRef.Namespace)
+		caSecretValues, err := r.getCACertificateFromSecret(ctx, helmReleaseProxy.Spec.TLSConfig.CASecretRef.Name, helmReleaseProxy.Namespace)
 		if err != nil {
 			return "", err
 		}

--- a/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
+++ b/controllers/helmreleaseproxy/helmreleaseproxy_controller_test.go
@@ -25,6 +25,7 @@ import (
 	helmRelease "helm.sh/helm/v3/pkg/release"
 	helmDriver "helm.sh/helm/v3/pkg/storage/driver"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -763,6 +764,34 @@ func TestTLSSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSecretReadsUseHelmReleaseProxyNamespace(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	foreignSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "tenant-b"},
+		Data: map[string][]byte{
+			"config.json": {},
+			"ca.crt":      {},
+		},
+	}
+	reconciler := &HelmReleaseProxyReconciler{
+		Client: fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(foreignSecret).Build(),
+	}
+
+	credentialsProxy := defaultProxyWithCredentialRef.DeepCopy()
+	credentialsProxy.Namespace = "tenant-a"
+	credentialsProxy.Spec.Credentials.Secret.Namespace = foreignSecret.Namespace
+	_, err := reconciler.getCredentials(ctx, credentialsProxy)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	caProxy := defaultProxyWithCACertRef.DeepCopy()
+	caProxy.Namespace = "tenant-a"
+	caProxy.Spec.TLSConfig.CASecretRef.Namespace = foreignSecret.Namespace
+	_, err = reconciler.getCAFile(ctx, caProxy)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }
 
 func init() {

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -131,7 +131,7 @@ $ HELM_REGISTRY_CONFIG=/tmp/oci-creds.json helm login <my-registry>
 Then, create a secret containing the credentials:
 
 ```bash
-$ kubectl create secret generic oci-creds --from-file=/tmp/oci-creds.json -n caaph-system
+$ kubectl create secret generic oci-creds --from-file=/tmp/oci-creds.json -n default
 ```
 
 You can then use your OCI registry by setting the `repoURL` to `oci://<my-registry>` and the credentials secret reference to `oci-creds`. For example:
@@ -143,8 +143,9 @@ spec:
     key: config.json
     secret:
       name: oci-creds
-      namespace: caaph-system
 ```
+
+The credentials Secret is resolved in the same namespace as the `HelmChartProxy`.
 
 Note that in this case the credentials in the secret must be stored in a file named `config.json` at the root of the secret, e.g:
 
@@ -153,7 +154,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: oci-creds
-  namespace: caaph-system
+  namespace: default
   data:
     config.json: <base64-encoded-credentials>
   type: Opaque


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves Secret reference isolation by resolving registry credentials and CA certificates in the owning proxy namespace. Adds validation, reconciliation safeguards, and regression coverage.
